### PR TITLE
Fix DynamicData.For memory leak

### DIFF
--- a/MonoMod.Utils/DynamicData.cs
+++ b/MonoMod.Utils/DynamicData.cs
@@ -153,7 +153,7 @@ namespace MonoMod.Utils {
         public static DynamicData For(object obj) {
             lock (_DynamicDataMap) {
                 if (!_DynamicDataMap.TryGetValue(obj, out DynamicData data)) {
-                    data = new DynamicData(obj);
+                    data = new DynamicData(obj.GetType(), obj, false);
                     _DynamicDataMap.Add(obj, data);
                 }
                 return data;


### PR DESCRIPTION
When using DynamicData.For, the constructed DynamicData objects have the `keepAlive` flag set. This causes a circular reference, as the instance now has a reference back to the object which is its key in `_DynamicDataMap` stored in `KeepAlive`. The effects are pretty severe, as once an object is used with `DynamicData.For`, it will never be collected by the GC. For Celeste mods, this can cause immense memory leaks, as they usually use `DynamicData.For` quite heavily on e.g. the `Player` object, which in turn has a reference back to the `Level` object, causing it (and the relatively large data structures it holds) to leak as well. The fix is to explicitly specify `keepAlive` to be false for `DynamicData` instances constructed using `DynamicData.For()`.