### PR TITLE
Fix "Hook already applied" message typo

### DIFF
--- a/src/MonoMod.RuntimeDetour/HookGen/HookEndpointManager.cs
+++ b/src/MonoMod.RuntimeDetour/HookGen/HookEndpointManager.cs
@@ -12,7 +12,7 @@ namespace MonoMod.RuntimeDetour.HookGen {
     public static class HookEndpointManager {
 
         private const string ObsoleteMessage = "This member should never be used directly from user code. Use Hook or ILHook directly instead.";
-        private const string HookAlreadyAppliedMsg = "Delegate has alreeady been applied to this method as a hook!";
+        private const string HookAlreadyAppliedMsg = "Delegate has already been applied to this method as a hook!";
 
         private static ConcurrentDictionary<(MethodBase, Delegate), Hook> Hooks = new();
         private static ConcurrentDictionary<(MethodBase, Delegate), ILHook> ILHooks = new();


### PR DESCRIPTION
There is a typo in the `HookAlreadyAppliedMsg` constant in `HookEndpointManager.cs` on the `reorganize` branch:
https://github.com/MonoMod/MonoMod/blob/269a5779d30dcfd46a7acc0a41271f9d1a637dd6/src/MonoMod.RuntimeDetour/HookGen/HookEndpointManager.cs#L15
The word `already` has an extra `e` in it.