### PR TITLE
Improve ILCursor label positioning behavior.

### DIFF
--- a/src/MonoMod.UnitTest/RuntimeDetour/ILCursorTest.cs
+++ b/src/MonoMod.UnitTest/RuntimeDetour/ILCursorTest.cs
@@ -44,7 +44,7 @@ namespace MonoMod.UnitTest {
         }
 
         private static void EmitThrowEx(ILCursor c) {
-            c.EmitNewobj(typeof(Exception).GetConstructors()[0]);
+            c.EmitNewobj(typeof(Exception).GetConstructor([]));
             c.EmitThrow();
         }
 

--- a/src/MonoMod.UnitTest/RuntimeDetour/ILCursorTest.cs
+++ b/src/MonoMod.UnitTest/RuntimeDetour/ILCursorTest.cs
@@ -1,0 +1,139 @@
+﻿extern alias New;
+
+using MonoMod.Cil;
+using New::MonoMod.RuntimeDetour;
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace MonoMod.UnitTest {
+    [Collection("RuntimeDetour")]
+    public class ILCursorTest : TestBase {
+        private class HookTest : IDisposable {
+            private ILHook _hook;
+
+            public HookTest(MethodBase method, Action<ILCursor> editor) {
+                _hook = new ILHook(method, il => {
+                    StripNops(il);
+                    editor(new ILCursor(il));
+                });
+            }
+
+            // Required for test to work in debug mode
+            private void StripNops(ILContext il) {
+                var c = new ILCursor(il);
+                while (c.TryGotoNext(i => i.MatchNop()))
+                    c.Remove();
+            }
+
+            public void Dispose() => _hook.Dispose();
+        }
+
+        public ILCursorTest(ITestOutputHelper helper) : base(helper) {
+        }
+
+        private static void EmitAppendTest(ILCursor c) {
+            c.EmitLdloc(0);
+            c.EmitLdstr("TEST");
+            c.EmitCallvirt(new Func<string, StringBuilder>(new StringBuilder().Append).Method);
+            c.EmitPop();
+        }
+
+        private static void EmitThrowEx(ILCursor c) {
+            c.EmitNewobj(typeof(Exception).GetConstructors()[0]);
+            c.EmitThrow();
+        }
+
+        private static string TestTryCatchFinallyILEdit(Action<ILCursor> editor) {
+            var method = new Func<string>(TryCatchFinally).Method;
+            Assert.Equal("trywhenfinallyreturn", TryCatchFinally());
+
+            using (new HookTest(method, editor)) {
+                return TryCatchFinally();
+            }
+        }
+
+        [Fact]
+        public void TestMoveBeforeTry() {
+            // Moves before the try-catch, so the exception is unhandled
+            Assert.Throws<Exception>(() => {
+                TestTryCatchFinallyILEdit(c => {
+                    c.GotoNext(MoveType.Before, i => i.MatchLdloc(0));
+                    EmitThrowEx(c);
+                });
+            });
+        }
+
+        [Fact]
+        public void TestMoveIntoTryStart() {
+            // Moves into the try-handler, triggering the general catch clause
+            Assert.Equal("catchfinallyreturn", 
+                TestTryCatchFinallyILEdit(c => {
+                    c.GotoNext(MoveType.AfterLabel, i => i.MatchLdloc(0));
+                    EmitThrowEx(c);
+                })
+            );
+        }
+
+        [Fact]
+        public void TestMoveIntoHandlerFilter() {
+            // Moves into the filter clause, even through the filter isn't triggered
+            Assert.Equal("TESTcatchfinallyreturn",
+                TestTryCatchFinallyILEdit(c => {
+                    c.GotoNext(MoveType.AfterLabel, i => i.MatchLdloc(0));
+                    EmitThrowEx(c);
+                    c.GotoNext(MoveType.AfterLabel, i => i.MatchIsinst(out _));
+                    EmitAppendTest(c);
+                })
+            );
+        }
+
+        [Fact]
+        public void TestMoveIntoHandler() {
+            // Deliberately moves into the catch clause with filter
+            Assert.Equal("tryTESTwhenfinallyreturn",
+                TestTryCatchFinallyILEdit(c => {
+                    c.Goto(c.Body.ExceptionHandlers.Single(eh => eh.FilterStart != null).HandlerStart, MoveType.AfterLabel);
+                    EmitAppendTest(c);
+                })
+            );
+        }
+
+        [Fact]
+        public void TestMoveAfterHandlers() {
+            // After the finally block
+            Assert.Equal("trywhenfinallyTESTreturn",
+                TestTryCatchFinallyILEdit(c => {
+                    c.GotoNext(MoveType.AfterLabel,
+                        i => i.MatchLdloc(0),
+                        i => i.MatchLdstr("return"));
+                    EmitAppendTest(c);
+                })
+            );
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        internal static string TryCatchFinally() {
+            var sb = new StringBuilder();
+            try {
+                sb.Append("try");
+                throw new ArgumentException("test");
+            }
+            catch (Exception ex) when (ex is ArgumentException) {
+                sb.Append("when");
+            }
+            catch {
+                sb.Append("catch");
+            }
+            finally {
+                sb.Append("finally");
+            }
+            sb.Append("return");
+            return sb.ToString();
+        }
+    }
+}

--- a/src/MonoMod.Utils/Cil/ILCursor.cs
+++ b/src/MonoMod.Utils/Cil/ILCursor.cs
@@ -473,6 +473,8 @@ namespace MonoMod.Cil {
         /// Remove the Next instruction
         /// </summary>
         public ILCursor Remove() {
+            MoveAfterLabels();
+
             var index = Index;
             _Retarget(Next?.Next, MoveType.Before);
             Instrs.RemoveAt(index);

--- a/src/MonoMod.Utils/Cil/ILCursor.cs
+++ b/src/MonoMod.Utils/Cil/ILCursor.cs
@@ -67,6 +67,7 @@ namespace MonoMod.Cil {
         // private state
         private Instruction? _next;
         private ILLabel[]? _afterLabels;
+        private Instruction? _afterEHTargets;
         private SearchTarget _searchTarget;
 
         /// <summary>
@@ -156,6 +157,7 @@ namespace MonoMod.Cil {
             _next = c._next;
             _searchTarget = c._searchTarget;
             _afterLabels = c._afterLabels;
+            _afterEHTargets = c._afterEHTargets;
         }
 
         /// <summary>
@@ -231,6 +233,7 @@ namespace MonoMod.Cil {
         /// <returns>this</returns>
         public ILCursor MoveAfterLabels() {
             _afterLabels = IncomingLabels.ToArray();
+            _afterEHTargets = Next;
             return this;
         }
 
@@ -240,6 +243,7 @@ namespace MonoMod.Cil {
         /// <returns>this</returns>
         public ILCursor MoveBeforeLabels() {
             _afterLabels = null;
+            _afterEHTargets = null;
             return this;
         }
 
@@ -493,6 +497,16 @@ namespace MonoMod.Cil {
             if (_afterLabels != null)
                 foreach (var label in _afterLabels)
                     label.Target = next;
+
+            if (_afterEHTargets != null)
+                foreach (var eh in Body.ExceptionHandlers) {
+                    if (eh.TryStart == _afterEHTargets) eh.TryStart = next;
+                    if (eh.TryEnd == _afterEHTargets) eh.TryEnd = next;
+                    if (eh.HandlerStart == _afterEHTargets) eh.HandlerStart = next;
+                    if (eh.HandlerEnd == _afterEHTargets) eh.HandlerEnd = next;
+                    if (eh.FilterStart == _afterEHTargets) eh.FilterStart = next;
+                }
+
             Goto(next, moveType);
         }
 

--- a/src/MonoMod.Utils/Cil/ILCursor.cs
+++ b/src/MonoMod.Utils/Cil/ILCursor.cs
@@ -1,4 +1,4 @@
-﻿using Mono.Cecil;
+using Mono.Cecil;
 using Mono.Cecil.Cil;
 using MonoMod.SourceGen.Attributes;
 using MonoMod.Utils;
@@ -486,7 +486,7 @@ namespace MonoMod.Cil {
         /// </summary>
         public ILCursor RemoveRange(int num) {
             var index = Index;
-            _Retarget(Instrs[index + num], MoveType.Before);
+            _Retarget(index + num < Instrs.Count ? Instrs[index + num] : null, MoveType.Before);
             while (num-- > 0) // TODO: currently requires O(n) removals, shifting the backing array each time
                 Instrs.RemoveAt(index);
             return this;

--- a/src/MonoMod.Utils/Cil/ILCursor.cs
+++ b/src/MonoMod.Utils/Cil/ILCursor.cs
@@ -1,4 +1,4 @@
-﻿using Mono.Cecil;
+using Mono.Cecil;
 using Mono.Cecil.Cil;
 using MonoMod.SourceGen.Attributes;
 using MonoMod.Utils;
@@ -67,8 +67,8 @@ namespace MonoMod.Cil {
         // private state
         private Instruction? _next;
         private ILLabel[]? _afterLabels;
-        private Instruction? _afterHandlerStarts;
-        private Instruction? _afterHandlerEnds;
+        private bool _afterHandlerStarts;
+        private bool _afterHandlerEnds;
         private SearchTarget _searchTarget;
 
         /// <summary>
@@ -238,10 +238,15 @@ namespace MonoMod.Cil {
             return this;
         }
 
+        /// <summary>
+        /// Move the cursor after incoming labels (branches). If an instruction is emitted, all labels which currently point to Next, will point to the newly emitted instruction.
+        /// </summary>
+        /// <param name="intoEHRanges">Whether to move the cursor into any try or catch ranges which start at the current position. Defaults to true.</param>
+        /// <returns>this</returns>
         public ILCursor MoveAfterLabels(bool intoEHRanges = true) {
             _afterLabels = IncomingLabels.ToArray();
-            _afterHandlerStarts = intoEHRanges ? Next : null;
-            _afterHandlerEnds = Next;
+            _afterHandlerStarts = intoEHRanges;
+            _afterHandlerEnds = true;
             return this;
         }
 
@@ -251,8 +256,8 @@ namespace MonoMod.Cil {
         /// <returns>this</returns>
         public ILCursor MoveBeforeLabels() {
             _afterLabels = null;
-            _afterHandlerStarts = null;
-            _afterHandlerEnds = null;
+            _afterHandlerStarts = false;
+            _afterHandlerEnds = false;
             return this;
         }
 
@@ -473,56 +478,63 @@ namespace MonoMod.Cil {
         public ILLabel DefineLabel() => Context.DefineLabel();
 
         private ILCursor _Insert(Instruction instr) {
+            // retargetting
+            if (_afterLabels != null)
+                foreach (var label in _afterLabels)
+                    label.Target = instr;
+
+            if (_afterHandlerStarts) {
+                foreach (var eh in Body.ExceptionHandlers) {
+                    if (eh.TryStart == Next) eh.TryStart = instr;
+                    if (eh.HandlerStart == Next) eh.HandlerStart = instr;
+                    if (eh.FilterStart == Next) eh.FilterStart = instr;
+                }
+            }
+
+            if (_afterHandlerEnds) {
+                foreach (var eh in Body.ExceptionHandlers) {
+                    if (eh.TryEnd == Next) eh.TryEnd = instr;
+                    if (eh.HandlerEnd == Next) eh.HandlerEnd = instr;
+                }
+            }
+
             Instrs.Insert(Index, instr);
-            _Retarget(instr, MoveType.After);
+            Goto(instr, MoveType.After);
             return this;
         }
 
         /// <summary>
-        /// Remove the Next instruction
+        /// Remove the Next instruction. Any labels or exception ranges pointing to the instruction will be moved to the following instruction. Cursor position will be maintained.
         /// </summary>
-        public ILCursor Remove() {
-            MoveAfterLabels();
-
-            var index = Index;
-            _Retarget(Next?.Next, MoveType.Before);
-            Instrs.RemoveAt(index);
-            return this;
-        }
+        public ILCursor Remove() => RemoveRange(1);
 
         /// <summary>
-        /// Remove several instructions
+        /// Remove several instructions. Any labels or exception ranges pointing to the instruction will be moved to the following instruction. Cursor position will be maintained.
         /// </summary>
         public ILCursor RemoveRange(int num) {
             var index = Index;
-            _Retarget(index + num < Instrs.Count ? Instrs[index + num] : null, MoveType.Before);
-            while (num-- > 0) // TODO: currently requires O(n) removals, shifting the backing array each time
+
+            // Retargetting
+            var newTarget = index + num < Instrs.Count ? Instrs[index + num] : null;
+            foreach (var label in IncomingLabels)
+                label.Target = newTarget;
+            
+            foreach (var eh in Body.ExceptionHandlers) {
+                if (eh.TryStart == Next) eh.TryStart = newTarget;
+                if (eh.TryEnd == Next) eh.TryEnd = newTarget;
+                if (eh.HandlerStart == Next) eh.HandlerStart = newTarget;
+                if (eh.FilterStart == Next) eh.FilterStart = newTarget;
+                if (eh.HandlerEnd == Next) eh.HandlerEnd = newTarget;
+            }
+
+            // TODO: currently requires O(n) removals, shifting the backing array each time
+            while (num-- > 0)
                 Instrs.RemoveAt(index);
+
+            _searchTarget = SearchTarget.None;
+            _next = newTarget;
+
             return this;
-        }
-
-        /// <summary>
-        /// Move the cursor and all labels the cursor is positioned after to a target instruction
-        /// </summary>
-        private void _Retarget(Instruction? next, MoveType moveType) {
-            if (_afterLabels != null)
-                foreach (var label in _afterLabels)
-                    label.Target = next;
-
-            if (_afterHandlerStarts != null)
-                foreach (var eh in Body.ExceptionHandlers) {
-                    if (eh.TryStart == _afterHandlerStarts) eh.TryStart = next;
-                    if (eh.HandlerStart == _afterHandlerStarts) eh.HandlerStart = next;
-                    if (eh.FilterStart == _afterHandlerStarts) eh.FilterStart = next;
-                }
-
-            if (_afterHandlerEnds != null)
-                foreach (var eh in Body.ExceptionHandlers) {
-                    if (eh.TryEnd == _afterHandlerEnds) eh.TryEnd = next;
-                    if (eh.HandlerEnd == _afterHandlerEnds) eh.HandlerEnd = next;
-                }
-
-            Goto(next, moveType);
         }
 
         /// <summary>


### PR DESCRIPTION
A couple of oversights/bugs in the initial implementation:
- `ILCursor.MoveAfterLabels` doesn't move into EH ranges at all. This means that editing instructions at the start of an try range, or immediately after a handler requires manual updating of the references in `Body.ExceptionHandlers`.
- `ILCursor.Remove` loses label positioning. As an example, removing the first instruction in an `else` block will repoint the incoming branch, but the cursor would move to before the branch requiring a `.MoveAfterLabels()` call to emit a replacement to the removed instruction.
- `ILCursor.Remove` will leave dangling labels or exception ranges when called without a preceding `.MoveAfterLabels()` call.

It is unlikely that many people are relying on the current deficient behaviour. Anyone who was working around the existing issues by calling `.MoveAfterLabels()` after `Remove`, or manually updating EH targets is also unlikely to be affected, this just makes such workarounds unnecessary.

See someone working around the lack of EH support in https://github.com/WEGFan/Celeste-Mod-China-Mirror/blob/7c7834f2e30087b846135b3beba99c27ca2be3fb/Modules/ChinaMirror.cs#L282C22-L282C38

Overall this should make `ILCursor` a little more featureful and robust. 

Not included:
- Support for specifying _which_ try range to emit in, when there are multiple that start at the same instruction. 
  - Reason: Any user with enough knowledge to write code distinguishing two handlers with the same try range can surely update the `HandlerStart` values themselves.