### PR TITLE
Fix NullReferenceException when logging marshalling helper types

### DIFF
--- a/src/MonoMod.Utils/Logs/DebugFormatter.cs
+++ b/src/MonoMod.Utils/Logs/DebugFormatter.cs
@@ -200,7 +200,7 @@ namespace MonoMod.Logs
             wrote = 0;
 
             string name;
-            if (type.HasElementType && type.GetElementType() == null) // marshalling helper types throw a NullReferenceException when accessing Namespace or FullName due to this apparent logic ontradiction
+            if (type.HasElementType && type.GetElementType() == null) // marshalling helper types throw a NullReferenceException when accessing Namespace or FullName due to this apparent logic contradiction
                 name = type.Name;
             else if (type.FullName is { } fullName)
                 name = fullName;

--- a/src/MonoMod.Utils/Logs/DebugFormatter.cs
+++ b/src/MonoMod.Utils/Logs/DebugFormatter.cs
@@ -199,9 +199,14 @@ namespace MonoMod.Logs
         {
             wrote = 0;
 
-            var name = type.FullName;
-            if (name is null)
+            string name;
+            if (type.HasElementType && type.GetElementType() == null) // marshalling helper types throw a NullReferenceException when accessing Namespace or FullName due to this apparent logic ontradiction
+                name = type.Name;
+            else if (type.FullName is { } fullName)
+                name = fullName;
+            else
                 return true;
+
             if (into.Length < name.Length)
                 return false;
             name.AsSpan().CopyTo(into);


### PR DESCRIPTION
When attempting to log the JIT of a marshalling stub, the type of one of the parameters may throw a `NullReferenceException` when accessing `FullName`.

Debugger shows the type as:
```
-        type    {Name = "VALUETYPEtf_callbacks*" FullName = {"Object reference not set to an instance of an object."}}    System.Type {System.RuntimeType}
+        type.GetElementType()    null    System.Type
+        type.HasElementType    true    bool
```

With the fix, we can correctly log:
```
[MonoMod.Core](4/5/2024 9:08:54 AM) Spam: JIT compiled System.Void (dynamicClass):IL_STUB_StructMarshal(Theorafile+tf_callbacks&, VALUETYPEtf_callbacks*, System.Int32, System.StubHelpers.CleanupWorkListElement&) to 0x00007ffe7b078660 (rw: 0x00007ffe7b078660)
```

Type being marshalled https://github.com/FNA-XNA/Theorafile/blob/master/csharp/Theorafile.cs#L118