### PR TITLE
Handle incorrect operand types more gracefully when using `ILPatternMatchingExt`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,11 +30,6 @@ env:
   DOTNET_TELEMETRY_OPTOUT: true
   DOTNET_NOLOGO: true
   NUGET_PACKAGES: ${{github.workspace}}/artifacts/pkg
-  
-# If new commits are pushed, don't bother finishing the current run.
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
-  cancel-in-progress: true
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,11 @@ env:
   DOTNET_TELEMETRY_OPTOUT: true
   DOTNET_NOLOGO: true
   NUGET_PACKAGES: ${{github.workspace}}/artifacts/pkg
+  
+# If new commits are pushed, don't bother finishing the current run.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,7 @@ jobs:
   
   build-testassets:
     needs: setup
+    if: needs.setup.outputs.should_skip != 'true'
     name: 'Build #${{ needs.setup.outputs.ver }} (Linux)'
     uses: ./.github/workflows/build.yml
     with:
@@ -69,6 +70,7 @@ jobs:
 
   build:
     needs: setup
+    if: needs.setup.outputs.should_skip != 'true'
     strategy:
       matrix:
         os: [windows-latest, macos-13]
@@ -89,6 +91,7 @@ jobs:
       
   test:
     needs: [setup, build-testassets]
+    if: needs.setup.outputs.should_skip != 'true'
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.setup.outputs.matrix) }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,6 @@ env:
   DOTNET_NOLOGO: true
   NUGET_PACKAGES: ${{github.workspace}}/artifacts/pkg
   
-# If new commits are pushed, don't bother finishing the current run.
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
-  cancel-in-progress: true
-
 # We'll have a job for building (that runs on x64 machines only, one for each OS to make sure it actually builds)
 # Then, we'll take the result from one of those (probaly Linux) and distribute build artifacts to testers to run
 # a load of tests. This will (eventually) include ARM runners, where possible.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,37 +12,41 @@ env:
   DOTNET_NOLOGO: true
   NUGET_PACKAGES: ${{github.workspace}}/artifacts/pkg
   
+# If new commits are pushed, don't bother finishing the current run.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: true
+
 # We'll have a job for building (that runs on x64 machines only, one for each OS to make sure it actually builds)
 # Then, we'll take the result from one of those (probaly Linux) and distribute build artifacts to testers to run
 # a load of tests. This will (eventually) include ARM runners, where possible.
 jobs:
-  event_file:
-    # This job uploads an event file so that our test aggregator and recorder can understand this event
-    name: "Event File"
+  setup:
+    name: Setup
     runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+      ver: ${{ steps.computever.outputs.ver }}
+      matrix: ${{ steps.compute-matrix.outputs.matrix }}
     steps:
-    - name: Upload
+    - name: Check if this run should skip
+      id: skip_check
+      uses: fkirc/skip-duplicate-actions@v5
+      with:
+        cancel_others: true
+        concurrent_skipping: same_content_newer
+
+    - name: Upload event file
       uses: actions/upload-artifact@v4
       with:
         name: test-event-file
         path: ${{ github.event_path }}
         retention-days: 1
-  
-  compute-version:
-    name: Compute Version
-    runs-on: ubuntu-latest
-    outputs:
-      ver: ${{ steps.computever.outputs.ver }}
-    steps:
-    - id: computever
+
+    - name: Compute Version
+      id: computever
       run: echo "ver=$(Get-Date -Format y.M.d).${{ github.run_number }}.${{ github.run_attempt }}" >> $env:GITHUB_OUTPUT
-      
-  compute-test-matrix:
-    name: Compute Test Matrix
-    runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.compute-matrix.outputs.matrix }}
-    steps:
+
     - name: Checkout
       uses: actions/checkout@v4
       with:
@@ -53,18 +57,18 @@ jobs:
       run: ./.github/gen-test-matrix.ps1 -MatrixOutName matrix -GithubOutput $env:GITHUB_OUTPUT
   
   build-testassets:
-    needs: compute-version
-    name: 'Build #${{ needs.compute-version.outputs.ver }} (Linux)'
+    needs: setup
+    name: 'Build #${{ needs.setup.outputs.ver }} (Linux)'
     uses: ./.github/workflows/build.yml
     with:
       os: ubuntu-latest
       osname: Linux
-      version: ${{ needs.compute-version.outputs.ver }}
+      version: ${{ needs.setup.outputs.ver }}
       upload-packages: true
       upload-tests: true
 
   build:
-    needs: compute-version
+    needs: setup
     strategy:
       matrix:
         os: [windows-latest, macos-13]
@@ -74,20 +78,20 @@ jobs:
         - os: macos-13
           name: MacOS
           
-    name: 'Build #${{ needs.compute-version.outputs.ver }} (${{ matrix.name }})'
+    name: 'Build #${{ needs.setup.outputs.ver }} (${{ matrix.name }})'
     uses: ./.github/workflows/build.yml
     with:
       os: ${{ matrix.os }}
       osname: ${{ matrix.name }}
-      version: ${{ needs.compute-version.outputs.ver }}
+      version: ${{ needs.setup.outputs.ver }}
       upload-packages: false
       upload-tests: false
       
   test:
-    needs: [compute-test-matrix, build-testassets]
+    needs: [setup, build-testassets]
     strategy:
       fail-fast: false
-      matrix: ${{ fromJSON(needs.compute-test-matrix.outputs.matrix) }}
+      matrix: ${{ fromJSON(needs.setup.outputs.matrix) }}
     uses: ./.github/workflows/test.yml
     name: Test ${{ matrix.title }}
     with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,11 @@ env:
   DOTNET_TELEMETRY_OPTOUT: true
   DOTNET_NOLOGO: true
   NUGET_PACKAGES: ${{github.workspace}}/artifacts/pkg
+  
+# If new commits are pushed, don't bother finishing the current run.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: true
 
 # We'll have a job for building (that runs on x64 machines only, one for each OS to make sure it actually builds)
 # Then, we'll take the result from one of those (probaly Linux) and distribute build artifacts to testers to run

--- a/.github/workflows/test_results.yml
+++ b/.github/workflows/test_results.yml
@@ -21,7 +21,7 @@ jobs:
       actions: read
 
     steps:
-    - name: Download test results
+    - name: Download event file
       uses: actions/download-artifact@v4
       with:
         run-id: ${{ github.event.workflow_run.id }}
@@ -36,19 +36,7 @@ jobs:
         github-token: ${{ github.token }}
         pattern: test-results *
         merge-multiple: false
-
-    #- name: Publish Test Results
-    #  uses: EnricoMi/publish-unit-test-result-action@v2
-    #  with:
-    #    commit: ${{ github.event.workflow_run.head_sha }}
-    #    event_file: event.json
-    #    event_name: ${{ github.event.workflow_run.event }}
-    #
-    #    files: '**/*.trx'
-    #    comment_mode: ${{ (github.event.workflow_run.event == 'pull_request' || github.event_name == 'pull_request') && 'failures' || 'off' }}
-    #    report_individual_runs: true
-    #    compare_to_earlier_commit: false
-
+        
     - name: Publish Test Results
       uses: nike4613/actions-test-results@v2
       with:

--- a/src/MonoMod.SourceGen.Internal/Cil/ILOverloadGenerator.cs
+++ b/src/MonoMod.SourceGen.Internal/Cil/ILOverloadGenerator.cs
@@ -429,7 +429,7 @@ namespace MonoMod.SourceGen.Internal.Cil
                     static void EmitMethodWithArg(CodeBuilder builder, string selfFqName, OpcodeDef op, string doc, string argType, string targetType, string argExpr)
                     {
                         _ = builder
-                            .WriteLine($"/// <summary>Emits a {doc} opcode with a <see cref=\"{argType}\"/> operand to the current cursor position.</summary>")
+                            .WriteLine($"/// <summary>Emits a {doc} opcode with a <see cref=\"{argType.Trim(['[', ']'])}\"/> operand to the current cursor position.</summary>")
                             .Write("""/// <param name="operand">The emitted instruction's operand.""");
                         if (argType != targetType)
                         {

--- a/src/MonoMod.SourceGen.Internal/Cil/ILOverloadGenerator.cs
+++ b/src/MonoMod.SourceGen.Internal/Cil/ILOverloadGenerator.cs
@@ -31,7 +31,7 @@ namespace MonoMod.SourceGen.Internal.Cil
             EquatableArray<SkipDefSet> SkipDefs,
             EquatableArray<SkipDefSet> SkipBaseOnlyDefs,
             EquatableArray<OpcodeDef> SForms,
-            EquatableArray<(OpcodeDef Op, string Doc)> Opcodes);
+            EquatableArray<(OpcodeDef Op, string? Doc)> Opcodes);
 
         public void Initialize(IncrementalGeneratorInitializationContext context)
         {
@@ -146,7 +146,7 @@ namespace MonoMod.SourceGen.Internal.Cil
             using var reader = new SourceTextReader(text.Text);
 
             using var usingsBuilder = ImmutableArrayBuilder<string>.Rent();
-            using var opcodeDefsBuilder = ImmutableArrayBuilder<(OpcodeDef, string)>.Rent();
+            using var opcodeDefsBuilder = ImmutableArrayBuilder<(OpcodeDef, string?)>.Rent();
             using var valueTypesBuilder = ImmutableArrayBuilder<string>.Rent();
             using var sformsBuilder = ImmutableArrayBuilder<OpcodeDef>.Rent();
 
@@ -275,7 +275,7 @@ namespace MonoMod.SourceGen.Internal.Cil
                 }
             }
 
-            static OpcodeDef? ParseOpcodeLine(string line, out string doc)
+            static OpcodeDef? ParseOpcodeLine(string line, out string? doc)
             {
                 var spcIdx = line.IndexOf(' ');
                 var tslashIdx = spcIdx < 0 ? -1 : line.IndexOf("///", spcIdx, StringComparison.Ordinal);
@@ -291,8 +291,7 @@ namespace MonoMod.SourceGen.Internal.Cil
                 if (string.IsNullOrEmpty(argType))
                     argType = null;
                 doc = line.Substring(tslashIdx < line.Length ? tslashIdx + 3 : tslashIdx).Trim();
-                if (string.IsNullOrEmpty(doc))
-                    doc = $"<see cref=\"OpCodes.{opcodeName}\"/>";
+                if (string.IsNullOrEmpty(doc)) doc = null;
 
                 return new OpcodeDef(opcodeName, opcodeName.Replace("_", ""), argType);
             }
@@ -371,6 +370,16 @@ namespace MonoMod.SourceGen.Internal.Cil
                 skipBaseOnlies = ImmutableArray.Create<OpcodeDef>();
         }
 
+        private static string GetOpcodeDoc(OpcodeDef def, bool hasSForm)
+        {
+            var str = $"<see cref=\"OpCodes.{def.Opcode}\"/>";
+            if (hasSForm)
+            {
+                str += $" or <see cref=\"OpCodes.{def.Opcode}_S\"/>";
+            }
+            return str;
+        }
+
         private static void GenerateCursorKind(SourceProductionContext spc, (TypeWithEmitOverloads type, ParsedDefFile defs) t)
         {
             var (type, defs) = t;
@@ -384,15 +393,18 @@ namespace MonoMod.SourceGen.Internal.Cil
             type.Type.AppendEnterContext(builder);
             GetConversionsAndSkips(type, defs, out var conversions, out var skips, out _);
 
-            foreach (var (op, doc) in defs.Opcodes)
+            foreach (var (op, explDoc) in defs.Opcodes)
             {
                 if (skips.Contains(op))
                     continue;
+
+                var doc = explDoc?? GetOpcodeDoc(op, defs.SForms.AsImmutableArray().Contains(op));
+
                 if (op.ArgumentType is null)
                 {
                     _ = builder
-                        .WriteLine($"""/// <summary>Emits a {doc} opcode to the current cursor position.</summary>""")
-                        .WriteLine("/// <returns>this</returns>")
+                        .WriteLine($"/// <summary>Emits a {doc} opcode to the current cursor position.</summary>")
+                        .WriteLine("/// <returns><see langword=\"this\"/></returns>")
                         .WriteLine($"public {type.Type.InnermostType.FqName} Emit{op.Formatted}() => _Insert(IL.Create(OpCodes.{op.Opcode}));")
                         .WriteLine();
                 }
@@ -417,11 +429,11 @@ namespace MonoMod.SourceGen.Internal.Cil
                     static void EmitMethodWithArg(CodeBuilder builder, string selfFqName, OpcodeDef op, string doc, string argType, string targetType, string argExpr)
                     {
                         _ = builder
-                            .WriteLine($"/// <summary>Emits a {doc} opcode with a <see cref=\"T:{argType}\"/> operand to the current cursor position.</summary>")
+                            .WriteLine($"/// <summary>Emits a {doc} opcode with a <see cref=\"{argType}\"/> operand to the current cursor position.</summary>")
                             .Write("""/// <param name="operand">The emitted instruction's operand.""");
                         if (argType != targetType)
                         {
-                            _ = builder.Write($$""" Will be automatically converted to a <see cref="T:{{targetType}}" />.""");
+                            _ = builder.Write($$""" Will be automatically converted to a <see cref="{{targetType.Trim(['[', ']'])}}" />.""");
                         }
                         _ = builder
                             .WriteLine("</param>")
@@ -451,15 +463,17 @@ namespace MonoMod.SourceGen.Internal.Cil
 
             GetConversionsAndSkips(type, defs, out var conversions, out var skips, out var skipBaseOnlies);
 
-            foreach (var (op, doc) in defs.Opcodes)
+            foreach (var (op, explDoc) in defs.Opcodes)
             {
                 if (skips.Contains(op))
                     continue;
 
+                var hasSForm = defs.SForms.AsImmutableArray().Contains(op);
+
                 var normalCond = $"global::MonoMod.Utils.Helpers.ThrowIfNull(instr).OpCode == OpCodes.{op.Opcode}";
-                var sformCond = defs.SForms.AsImmutableArray().Contains(op)
-                    ? $" || instr.OpCode == OpCodes.{op.Opcode}_S"
-                    : "";
+                var sformCond = hasSForm ? $" || instr.OpCode == OpCodes.{op.Opcode}_S" : "";
+
+                var doc = explDoc ?? GetOpcodeDoc(op, hasSForm);
 
                 var matchCond = normalCond + sformCond;
 
@@ -488,22 +502,22 @@ namespace MonoMod.SourceGen.Internal.Cil
                             .WriteLine("/// <returns><see langword=\"true\"/> if the instruction matches; <see langword=\"false\"/> otherwise.</returns>")
                             .WriteLine($"public static bool Match{op.Formatted}(this Instruction instr, [global::System.Diagnostics.CodeAnalysis.MaybeNullWhen(false)] out {op.ArgumentType} value)")
                             .OpenBlock()
-                            .WriteLine($"if ({matchCond})")
+                            .WriteLine($"if (({matchCond}) && instr.Operand is {op.ArgumentType} op)")
                             .OpenBlock()
-                            .WriteLine($"value = ({op.ArgumentType})instr.Operand;")
-                            .WriteLine("return true;")
+                                .WriteLine("value = op;")
+                                .WriteLine("return true;")
                             .CloseBlock()
                             .WriteLine("else")
                             .OpenBlock()
-                            .WriteLine("value = default;")
-                            .WriteLine("return false;")
+                                .WriteLine("value = default;")
+                                .WriteLine("return false;")
                             .CloseBlock()
                             .CloseBlock()
                             .WriteLine();
                     }
 
                     _ = builder
-                        .WriteLine($"/// <summary>Matches an instruction with opcode {doc} .</summary>")
+                        .WriteLine($"/// <summary>Matches an instruction with opcode {doc}.</summary>")
                         .WriteLine("/// <param name=\"instr\">The instruction to try to match.</param>")
                         .WriteLine("/// <param name=\"value\">The operand value required for the instruction to match.</param>")
                         .WriteLine("/// <returns><see langword=\"true\"/> if the instruction matches; <see langword=\"false\"/> otherwise.</returns>")

--- a/src/MonoMod.UnitTest/ILPatternMatcherTests.cs
+++ b/src/MonoMod.UnitTest/ILPatternMatcherTests.cs
@@ -1,0 +1,48 @@
+﻿using MonoMod.Cil;
+using MonoMod.Utils;
+using System.Reflection;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace MonoMod.UnitTest
+{
+    public sealed class ILPatternMatcherTests : TestBase
+    {
+        public ILPatternMatcherTests(ITestOutputHelper helper) : base(helper)
+        {
+        }
+
+        [Fact]
+        public void ILMatcherDoesNotThrowMatchingDynamicMethodRef()
+        {
+            MethodInfo dm;
+            using (var dmd1 = new DynamicMethodDefinition("Test DM 1", typeof(void), []))
+            {
+                using var ilctx = new ILContext(dmd1.Definition);
+                var il = new ILCursor(ilctx);
+
+                il.EmitRet();
+
+                dm = dmd1.Generate();
+            }
+
+            using (var dmd2 = new DynamicMethodDefinition("Test DM 2", typeof(void), []))
+            {
+                using var ilctx = new ILContext(dmd2.Definition);
+                var il = new ILCursor(ilctx);
+
+                il.EmitCall(dm);
+                // also emit with ilprocessor directly
+                ilctx.IL.Emit(Mono.Cecil.Cil.OpCodes.Call, dm);
+                il.EmitRet();
+
+                // now for the actual test: lets try to match that call against a Console.WriteLine
+                il.Goto(0);
+                Assert.False(il.TryGotoNext(i => i.MatchCallOrCallvirt(typeof(System.Console), "WriteLine")));
+
+                // DM should also be compilable
+                _ = dmd2.Generate();
+            }
+        }
+    }
+}

--- a/src/MonoMod.Utils/Cil/ILCursor.cs
+++ b/src/MonoMod.Utils/Cil/ILCursor.cs
@@ -221,7 +221,7 @@ namespace MonoMod.Cil
         /// <param name="insn">The target instruction</param>
         /// <param name="moveType">Where to move in relation to the target instruction and incoming labels (branches)</param>
         /// <param name="setTarget">Whether to set the `SearchTarget` and skip the target instruction with the next search function</param>
-        /// <returns>this</returns>
+        /// <returns><see langword="this"/></returns>
         public ILCursor Goto(Instruction? insn, MoveType moveType = MoveType.Before, bool setTarget = false)
         {
             if (moveType == MoveType.After)
@@ -246,7 +246,7 @@ namespace MonoMod.Cil
         /// <summary>
         /// Move the cursor after incoming labels (branches). If an instruction is emitted, all labels which currently point to Next, will point to the newly emitted instruction.
         /// </summary>
-        /// <returns>this</returns>
+        /// <returns><see langword="this"/></returns>
         public ILCursor MoveAfterLabels()
         {
             MoveAfterLabels(intoEHRanges: true);
@@ -257,7 +257,7 @@ namespace MonoMod.Cil
         /// Move the cursor after incoming labels (branches). If an instruction is emitted, all labels which currently point to Next, will point to the newly emitted instruction.
         /// </summary>
         /// <param name="intoEHRanges">Whether to move the cursor into any try or catch ranges which start at the current position. Defaults to true.</param>
-        /// <returns>this</returns>
+        /// <returns><see langword="this"/></returns>
         public ILCursor MoveAfterLabels(bool intoEHRanges)
         {
             _afterLabels = IncomingLabels.ToArray();
@@ -269,7 +269,7 @@ namespace MonoMod.Cil
         /// <summary>
         /// Move the cursor before incoming labels (branches). This is the default behaviour. Emitted instructions will not cause labels to change targets.
         /// </summary>
-        /// <returns>this</returns>
+        /// <returns><see langword="this"/></returns>
         public ILCursor MoveBeforeLabels()
         {
             _afterLabels = null;
@@ -281,7 +281,7 @@ namespace MonoMod.Cil
         /// <summary>
         /// Move the cursor to a target index. Supports negative indexing. See <see cref="Goto(Instruction, MoveType, bool)"/>
         /// </summary>
-        /// <returns>this</returns>
+        /// <returns><see langword="this"/></returns>
         public ILCursor Goto(int index, MoveType moveType = MoveType.Before, bool setTarget = false)
         {
             if (index < 0)
@@ -293,15 +293,15 @@ namespace MonoMod.Cil
         /// <summary>
         /// Overload for <c>Goto(label.Target)</c>. <paramref name="moveType"/> defaults to MoveType.AfterLabel
         /// </summary>
-        /// <returns>this</returns>
+        /// <returns><see langword="this"/></returns>
         public ILCursor GotoLabel(ILLabel label, MoveType moveType = MoveType.AfterLabel, bool setTarget = false)
             => Goto(Helpers.ThrowIfNull(label).Target, moveType, setTarget);
 
         /// <summary>
         /// Search forward and moves the cursor to the next sequence of instructions matching the corresponding predicates. See also <seealso cref="ILCursor.TryGotoNext(MoveType, Func{Instruction, bool}[])"/>
         /// </summary>
-        /// <returns>this</returns>
-        /// <exception cref="KeyNotFoundException">If no match is found</exception>
+        /// <returns><see langword="this"/></returns>
+        /// <exception cref="KeyNotFoundException">Thrown if no match is found</exception>
         public ILCursor GotoNext(MoveType moveType = MoveType.Before, params Func<Instruction, bool>[] predicates)
         {
             if (!TryGotoNext(moveType, predicates))
@@ -313,7 +313,7 @@ namespace MonoMod.Cil
         /// <summary>
         /// Search forward and moves the cursor to the next sequence of instructions matching the corresponding predicates.
         /// </summary>
-        /// <returns>True if a match was found</returns>
+        /// <returns><see langword="true"/> if a matching instruction was found; <see langword="false"/> if one was not.</returns>
         public bool TryGotoNext(MoveType moveType = MoveType.Before, params Func<Instruction, bool>[] predicates)
         {
             Helpers.ThrowIfArgumentNull(predicates);
@@ -345,8 +345,8 @@ namespace MonoMod.Cil
         /// <summary>
         /// Search backward and moves the cursor to the next sequence of instructions matching the corresponding predicates. See also <seealso cref="TryGotoPrev(MoveType, Func{Instruction, bool}[])"/>
         /// </summary>
-        /// <returns>this</returns>
-        /// <exception cref="KeyNotFoundException">If no match is found</exception>
+        /// <returns><see langword="this"/></returns>
+        /// <exception cref="KeyNotFoundException">Thrown if no match is found</exception>
         public ILCursor GotoPrev(MoveType moveType = MoveType.Before, params Func<Instruction, bool>[] predicates)
         {
             if (!TryGotoPrev(moveType, predicates))
@@ -358,7 +358,7 @@ namespace MonoMod.Cil
         /// <summary>
         /// Search backward and moves the cursor to the next sequence of instructions matching the corresponding predicates.
         /// </summary>
-        /// <returns>True if a match was found</returns>
+        /// <returns><see langword="true"/> if a matching instruction was found; <see langword="false"/> if one was not.</returns>
         public bool TryGotoPrev(MoveType moveType = MoveType.Before, params Func<Instruction, bool>[] predicates)
         {
             Helpers.ThrowIfArgumentNull(predicates);
@@ -384,9 +384,28 @@ namespace MonoMod.Cil
         }
 
         // manual overloads for params + default args
+
+        /// <summary>
+        /// Search forward and moves the cursor to the next sequence of instructions matching the corresponding predicates. See also <seealso cref="ILCursor.TryGotoNext(MoveType, Func{Instruction, bool}[])"/>
+        /// </summary>
+        /// <returns><see langword="this"/></returns>
+        /// <exception cref="KeyNotFoundException">Thrown if no match is found</exception>
         public ILCursor GotoNext(params Func<Instruction, bool>[] predicates) => GotoNext(MoveType.Before, predicates);
+        /// <summary>
+        /// Search forward and moves the cursor to the next sequence of instructions matching the corresponding predicates.
+        /// </summary>
+        /// <returns><see langword="true"/> if a matching instruction was found; <see langword="false"/> if one was not.</returns>
         public bool TryGotoNext(params Func<Instruction, bool>[] predicates) => TryGotoNext(MoveType.Before, predicates);
+        /// <summary>
+        /// Search backward and moves the cursor to the next sequence of instructions matching the corresponding predicates. See also <seealso cref="TryGotoPrev(MoveType, Func{Instruction, bool}[])"/>
+        /// </summary>
+        /// <returns><see langword="this"/></returns>
+        /// <exception cref="KeyNotFoundException">Thrown if no match is found</exception>
         public ILCursor GotoPrev(params Func<Instruction, bool>[] predicates) => GotoPrev(MoveType.Before, predicates);
+        /// <summary>
+        /// Search backward and moves the cursor to the next sequence of instructions matching the corresponding predicates.
+        /// </summary>
+        /// <returns><see langword="true"/> if a matching instruction was found; <see langword="false"/> if one was not.</returns>
         public bool TryGotoPrev(params Func<Instruction, bool>[] predicates) => TryGotoPrev(MoveType.Before, predicates);
 
         #endregion

--- a/src/MonoMod.Utils/Cil/ILOpcodes.txt
+++ b/src/MonoMod.Utils/Cil/ILOpcodes.txt
@@ -28,31 +28,31 @@ double
 #
 # This definition is for ILCursor generation. They will only be used for that.
 [Conversions ILCursor]
-Type -> TypeReference                   : Context.Import(operand)
-Type -> IMetadataTokenProvider          : Context.Import(operand)
-FieldInfo -> FieldReference             : Context.Import(operand)
-FieldInfo -> IMetadataTokenProvider     : Context.Import(operand)
-MethodBase -> MethodReference           : Context.Import(operand)
-MethodBase -> IMetadataTokenProvider    : Context.Import(operand)
-uint -> int                             : unchecked((int)operand)
-ulong -> long                           : unchecked((long)operand)
-Instruction -> ILLabel                  : MarkLabel(operand)
-Instruction[] -> ILLabel[]              : operand.Select(MarkLabel).ToArray()
+Type            -> TypeReference            : Context.Import(operand)
+Type            -> IMetadataTokenProvider   : Context.Import(operand)
+FieldInfo       -> FieldReference           : Context.Import(operand)
+FieldInfo       -> IMetadataTokenProvider   : Context.Import(operand)
+MethodBase      -> MethodReference          : Context.Import(operand)
+MethodBase      -> IMetadataTokenProvider   : Context.Import(operand)
+uint            -> int                      : unchecked((int)operand)
+ulong           -> long                     : unchecked((long)operand)
+Instruction     -> ILLabel                  : MarkLabel(operand)
+Instruction[]   -> ILLabel[]                : operand.Select(MarkLabel).ToArray()
 
 # ILMatcher definitions don't have a convertExpr, because we don't need to create
-# instances of the target type. Instead, we comparee against them, using IsEquivalent
+# instances of the target type. Instead, we compare against them, using IsEquivalent
 # definitions in the type being generated into.
 [Conversions ILMatcher]
-Type -> TypeReference                   :
-Type -> IMetadataTokenProvider          :
-FieldInfo -> FieldReference             :
-FieldInfo -> IMetadataTokenProvider     :
-MethodBase -> MethodReference           :
-MethodBase -> IMetadataTokenProvider    :
-uint -> int                             :
-ulong -> long                           :
-Instruction -> ILLabel                  :
-Instruction[] -> ILLabel[]              :
+Type            -> TypeReference            :
+Type            -> IMetadataTokenProvider   :
+FieldInfo       -> FieldReference           :
+FieldInfo       -> IMetadataTokenProvider   :
+MethodBase      -> MethodReference          :
+MethodBase      -> IMetadataTokenProvider   :
+uint            -> int                      :
+ulong           -> long                     :
+Instruction     -> ILLabel                  :
+Instruction[]   -> ILLabel[]                :
 
 # Skip definitions.
 # These are Opcode definitions which will get skipped for the respective generator kinds.
@@ -83,7 +83,7 @@ Ldloc VariableReference
 Ldloca VariableReference
 Stloc VariableReference
 
-# S-Form list
+# S-Form list (instructions which have _S variants)
 [SForm]
 Ldarg int
 Ldarg ParameterReference

--- a/src/MonoMod.Utils/Cil/ILPatternMatchingExt.cs
+++ b/src/MonoMod.Utils/Cil/ILPatternMatchingExt.cs
@@ -135,9 +135,9 @@ namespace MonoMod.Cil
         public static bool Match<T>(this Instruction instr, OpCode opcode, [MaybeNullWhen(false)] out T value)
         {
             Helpers.ThrowIfArgumentNull(instr);
-            if (instr.OpCode == opcode)
+            if (instr.OpCode == opcode && instr.Operand is T operand)
             {
-                value = (T)instr.Operand;
+                value = operand;
                 return true;
             }
             else
@@ -458,9 +458,9 @@ namespace MonoMod.Cil
         public static bool MatchCallOrCallvirt(this Instruction instr, [MaybeNullWhen(false)] out MethodReference value)
         {
             Helpers.ThrowIfArgumentNull(instr);
-            if (instr.OpCode == OpCodes.Call || instr.OpCode == OpCodes.Callvirt)
+            if ((instr.OpCode == OpCodes.Call || instr.OpCode == OpCodes.Callvirt) && instr.Operand is MethodReference mr)
             {
-                value = (MethodReference)instr.Operand;
+                value = mr;
                 return true;
             }
             else

--- a/src/MonoMod.Utils/Cil/ILPatternMatchingExt.cs
+++ b/src/MonoMod.Utils/Cil/ILPatternMatchingExt.cs
@@ -214,6 +214,20 @@ namespace MonoMod.Cil
             }
         }
 
+        private static int ParameterToIndex(object? obj)
+            => obj switch
+            {
+                null => 0,
+                int i => i,
+                short i => i,
+                uint i => (int)i,
+                ushort i => i,
+                byte i => i,
+                sbyte i => i,
+                ParameterReference pr => pr.Index,
+                _ => throw new InvalidCastException(),
+            };
+
         /// <summary>Matches an instruction with opcode <see cref="OpCodes.Starg"/>.</summary>
         /// <param name="instr">The instruction to try to match.</param>
         /// <param name="value">The operand value of the instruction.</param>
@@ -223,7 +237,7 @@ namespace MonoMod.Cil
             Helpers.ThrowIfArgumentNull(instr);
             if (instr.OpCode == OpCodes.Starg || instr.OpCode == OpCodes.Starg_S)
             {
-                value = ((ParameterReference)instr.Operand).Index;
+                value = ParameterToIndex(instr.Operand);
                 return true;
             }
             else
@@ -242,7 +256,7 @@ namespace MonoMod.Cil
             Helpers.ThrowIfArgumentNull(instr);
             if (instr.OpCode == OpCodes.Ldarga || instr.OpCode == OpCodes.Ldarga_S)
             {
-                value = ((ParameterReference)instr.Operand).Index;
+                value = ParameterToIndex(instr.Operand);
                 return true;
             }
             else
@@ -251,6 +265,20 @@ namespace MonoMod.Cil
                 return false;
             }
         }
+
+        private static int VarToIndex(object? obj)
+            => obj switch
+            {
+                null => 0,
+                int i => i,
+                short i => i,
+                uint i => (int)i,
+                ushort i => i,
+                byte i => i,
+                sbyte i => i,
+                VariableReference vr => vr.Index,
+                _ => throw new InvalidCastException(),
+            };
 
         /// <summary>Matches an instruction with opcode <see cref="OpCodes.Ldloc"/>.</summary>
         /// <param name="instr">The instruction to try to match.</param>
@@ -261,7 +289,7 @@ namespace MonoMod.Cil
             Helpers.ThrowIfArgumentNull(instr);
             if (instr.OpCode == OpCodes.Ldloc || instr.OpCode == OpCodes.Ldloc_S)
             {
-                value = ((VariableReference)instr.Operand).Index;
+                value = VarToIndex(instr.Operand);
                 return true;
             }
             else if (instr.OpCode == OpCodes.Ldloc_0)
@@ -300,7 +328,7 @@ namespace MonoMod.Cil
             Helpers.ThrowIfArgumentNull(instr);
             if (instr.OpCode == OpCodes.Stloc || instr.OpCode == OpCodes.Stloc_S)
             {
-                value = ((VariableReference)instr.Operand).Index;
+                value = VarToIndex(instr.Operand);
                 return true;
             }
             else if (instr.OpCode == OpCodes.Stloc_0)
@@ -339,7 +367,7 @@ namespace MonoMod.Cil
             Helpers.ThrowIfArgumentNull(instr);
             if (instr.OpCode == OpCodes.Ldloca || instr.OpCode == OpCodes.Ldloca_S)
             {
-                value = ((VariableReference)instr.Operand).Index;
+                value = VarToIndex(instr.Operand);
                 return true;
             }
             else

--- a/src/MonoMod.Utils/Extensions.UtilsIL.cs
+++ b/src/MonoMod.Utils/Extensions.UtilsIL.cs
@@ -137,8 +137,6 @@ namespace MonoMod.Utils
         public static Instruction Create(this ILProcessor il, OpCode opcode, MethodBase method)
         {
             Helpers.ThrowIfArgumentNull(il);
-            if (method is System.Reflection.Emit.DynamicMethod)
-                return il.Create(opcode, (object)method);
             return il.Create(opcode, il.Import(method));
         }
         public static Instruction Create(this ILProcessor il, OpCode opcode, Type type)
@@ -173,11 +171,6 @@ namespace MonoMod.Utils
         {
             Helpers.ThrowIfArgumentNull(il);
             Helpers.ThrowIfArgumentNull(method);
-            if (method is System.Reflection.Emit.DynamicMethod)
-            {
-                il.Emit(opcode, (object)method);
-                return;
-            }
             il.Emit(opcode, il.Import(method));
         }
         public static void Emit(this ILProcessor il, OpCode opcode, Type type)

--- a/tools/Common.CS.props
+++ b/tools/Common.CS.props
@@ -40,7 +40,7 @@
     <NewCecilVersion>0.11.5</NewCecilVersion>
     <OldCecilVersion>0.10.4</OldCecilVersion>
     
-    <RoslynVersion>4.8.0</RoslynVersion>
+    <RoslynVersion>4.9.2</RoslynVersion>
     <MSBuildRequiredVersion>17.8.3</MSBuildRequiredVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
Normally, operand types are all correct. However, if we ever are trying to emit a call to a `DynamicMethod`, we have to store a direct reference to that DM, without a `MethodReference`. This is technically incorrect, but the only way to handle it.