### PR TITLE
Fix the DocFX build

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "docfx": {
-      "version": "2.76.0",
+      "version": "2.77.0",
       "commands": [
         "docfx"
       ],

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,6 +24,9 @@ env:
   DOTNET_TELEMETRY_OPTOUT: true
   DOTNET_NOLOGO: true
   NUGET_PACKAGES: ${{github.workspace}}/artifacts/pkg
+  # We have to force the Roslyn version to be 4.10, because docfx ships that version, and if we target newer for the DocFX build,
+  # our source generators won't load,
+  RoslynVersion: 4.10.0
 
 jobs:
   publish-docs:

--- a/docfx/docfx.json
+++ b/docfx/docfx.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/dotnet/docfx/main/schemas/docfx.schema.json",
   "metadata": [
     {
       "src": [
@@ -28,7 +29,11 @@
       "categoryLayout": "nested",
       "namespaceLayout": "flattened",
       "memberLayout": "separatePages",
-      "enumSortOrder": "declaringOrder"
+      "enumSortOrder": "declaringOrder",
+      "noRestore": true,
+      "properties": {
+        "TargetFramework": "net8.0"
+      }
     }
   ],
   "build": {
@@ -76,12 +81,13 @@
       }
     ],
     "dest": "_site",
-    "globalMetadataFiles": ["globalmeta.json"],
+    "globalMetadataFiles": [ "globalmeta.json" ],
     "fileMetadataFiles": [],
     "template": [
-      "default", "modern"
+      "default",
+      "modern"
     ],
-    "postProcessors": ["ExtractSearchIndex"],
+    "postProcessors": [ "ExtractSearchIndex" ],
     "markdownEngineName": "markdig",
     "noLangKeyword": false,
     "keepFileLink": false,

--- a/docs/README.Core.md
+++ b/docs/README.Core.md
@@ -10,7 +10,7 @@
 ## Usage
 
 Use `DetourFactory.Current.CreateDetour` to create a single detour from one method to another. The detour will be
-automatically undone when the returnedc object is disposed or garbage collected. Only one such detour may be made per
+automatically undone when the returned object is disposed or garbage collected. Only one such detour may be made per
 method. If multiple are made, they will not be cleaned up properly. `MonoMod.Core` does not track which methods have
 already been detoured, and will not throw.
 

--- a/src/MonoMod.RuntimeDetour/HookGen/HookEndpointManager.cs
+++ b/src/MonoMod.RuntimeDetour/HookGen/HookEndpointManager.cs
@@ -12,7 +12,6 @@ namespace MonoMod.RuntimeDetour.HookGen
     /// </summary>
     public static class HookEndpointManager
     {
-
         private const string ObsoleteMessage = "This member should never be used directly from user code. Use Hook or ILHook directly instead.";
         private const string HookAlreadyAppliedMsg = "Delegate has already been applied to this method as a hook!";
 


### PR DESCRIPTION
Upgrading Roslyn previously caused DocFX to fail because it ships its own Roslyn, breaking our SGs. For DocFX, we can force using the version of Roslyn shipped with DocFX.