### PR TITLE
Add an ABI fixup for generic context

### DIFF
--- a/src/MonoMod.Core/CompatibilitySuppressions.xml
+++ b/src/MonoMod.Core/CompatibilitySuppressions.xml
@@ -1,6 +1,48 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- https://learn.microsoft.com/dotnet/fundamentals/package-validation/diagnostic-ids -->
 <Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
+    <Target>M:MonoMod.Core.Platforms.IRuntime.RequiresGenericContext(System.Reflection.MethodBase)</Target>
+    <Left>lib/net35/MonoMod.Core.dll</Left>
+    <Right>lib/net35/MonoMod.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
+    <Target>M:MonoMod.Core.Platforms.IRuntime.RequiresGenericContext(System.Reflection.MethodBase)</Target>
+    <Left>lib/net452/MonoMod.Core.dll</Left>
+    <Right>lib/net452/MonoMod.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
+    <Target>M:MonoMod.Core.Platforms.IRuntime.RequiresGenericContext(System.Reflection.MethodBase)</Target>
+    <Left>lib/net5.0/MonoMod.Core.dll</Left>
+    <Right>lib/net5.0/MonoMod.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
+    <Target>M:MonoMod.Core.Platforms.IRuntime.RequiresGenericContext(System.Reflection.MethodBase)</Target>
+    <Left>lib/net6.0/MonoMod.Core.dll</Left>
+    <Right>lib/net6.0/MonoMod.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
+    <Target>M:MonoMod.Core.Platforms.IRuntime.RequiresGenericContext(System.Reflection.MethodBase)</Target>
+    <Left>lib/net7.0/MonoMod.Core.dll</Left>
+    <Right>lib/net7.0/MonoMod.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
+    <Target>M:MonoMod.Core.Platforms.IRuntime.RequiresGenericContext(System.Reflection.MethodBase)</Target>
+    <Left>lib/netstandard2.0/MonoMod.Core.dll</Left>
+    <Right>lib/netstandard2.0/MonoMod.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
   <Suppression>
     <DiagnosticId>CP0011</DiagnosticId>
     <Target>F:Iced.Intel.MemorySize.Broadcast128_2xBFloat16</Target>

--- a/src/MonoMod.Core/Platforms/IRuntime.cs
+++ b/src/MonoMod.Core/Platforms/IRuntime.cs
@@ -56,6 +56,16 @@ namespace MonoMod.Core.Platforms
         RuntimeMethodHandle GetMethodHandle(MethodBase method);
 
         /// <summary>
+        /// Determines whether a particular method requires a generic context to be provided to it by the runtime.
+        /// </summary>
+        /// <param name="method">The method to check.</param>
+        /// <returns>
+        /// <c>true</c> if the method requires a generic context to be provided to it by the runtime;
+        /// otherwise, <c>false</c>.
+        /// </returns>
+        bool RequiresGenericContext(MethodBase method);
+
+        /// <summary>
         /// Disables inlining for a particular method. After this is called, future invocations of this method will not be inlined at the callsite by the runtime.
         /// </summary>
         /// <remarks>

--- a/src/MonoMod.Core/Platforms/PlatformTriple.cs
+++ b/src/MonoMod.Core/Platforms/PlatformTriple.cs
@@ -1,4 +1,4 @@
-﻿using Mono.Cecil.Cil;
+using Mono.Cecil.Cil;
 using MonoMod.Backports;
 using MonoMod.Core.Utils;
 using MonoMod.Logs;
@@ -629,106 +629,120 @@ namespace MonoMod.Core.Platforms
             Helpers.ThrowIfArgumentNull(from);
             Helpers.ThrowIfArgumentNull(to);
 
+            // TODO: check that `from` and `to` are actually argument- and return-compatible.
+            // When we use this method internally, all the necessary checks are already performed
+            // elsewhere, so we do not need to repeat them here. However, this method is part of
+            // the public API, and currently, it produces faulty results for unsanitized inputs.
+            // So, maybe we should do something about that.
+
             to = GetIdentifiable(to);
+            if (from is not MethodInfo fromInfo || to is not MethodInfo toInfo)
+                return to;
 
-            // TODO: check that from and to are actually argument- and return-compatible
-            // this check would ensure that to is only non-static when that makes sense
+            // Whenever we detour a call from an instance method to a static one, `this` needs to
+            // change its position to morph into a simple argument. Otherwise, it will be swapped
+            // with the return buffer, causing a spectacular failure on the callee side:
+            //
+            // Argument order for the instance method: [ThisPointer,  ReturnBuffer, UserArguments]
+            // Argument order for the static method:   [ReturnBuffer, ThisPointer,  UserArguments]
+            //
+            // Note that this fixup is only relevant when there is a return buffer between `this`
+            // and the user arguments to begin with. Otherwise, both instance and static methods
+            // will have the exact same effective argument order: [ThisPointer, UserArguments].
+            // A return buffer is only present in scenarios where a value is returned by reference.
+            //
+            // Consequently, there is no need for a fixup for ABIs that declare argument order
+            // like this: [ReturnBuffer, ThisPointer, UserArguments] (e.g., Mono on Linux).
+            // While there is no need, there is also no harm in applying it anyways, as it will
+            // act as a simple passthrough.
+            // However, TODO: this scenario can be optimized out of existence.
+            var returnType = fromInfo.ReturnType;
+            var hasReturnBuffer = Abi.Classify(returnType, true) is TypeClassification.ByReference;
+            var hasThis = !fromInfo.IsStatic;
+            var requiresReturnBufferFixup = hasThis && toInfo.IsStatic && hasReturnBuffer;
 
-            if (from is MethodInfo fromInfo &&
-                to is MethodInfo toInfo &&
-                !fromInfo.IsStatic && to.IsStatic)
+            // Check if a fixup is needed for the current scenario.
+            if (!requiresReturnBufferFixup)
             {
-                var retType = fromInfo.ReturnType;
-                // if from has `this` and to doesn't, then we need to fix up the abi
-                var returnClass = Abi.Classify(retType, true);
-
-                // only if the return class is ByRef do we need to do something
-                // TODO: perform better decisions based on the ABI argument order and return class
-                if (returnClass == TypeClassification.ByReference)
-                {
-                    var thisType = from.GetThisParamType();
-                    var retPtrType = retType.MakeByRefType();
-
-                    var newRetType = Abi.ReturnsReturnBuffer ? retPtrType : typeof(void);
-
-                    int thisPos = -1, retBufPos = -1, argOffset = -1;
-
-                    var paramList = from.GetParameters();
-
-                    var argTypes = new List<Type>();
-                    var order = Abi.ArgumentOrder.Span;
-                    for (var i = 0; i < order.Length; i++)
-                    {
-                        var kind = order[i];
-
-                        if (kind == SpecialArgumentKind.ThisPointer)
-                        {
-                            thisPos = argTypes.Count;
-                            argTypes.Add(thisType);
-                        }
-                        else if (kind == SpecialArgumentKind.ReturnBuffer)
-                        {
-                            retBufPos = argTypes.Count;
-                            argTypes.Add(retPtrType);
-                        }
-                        else if (kind == SpecialArgumentKind.UserArguments)
-                        {
-                            argOffset = argTypes.Count;
-                            argTypes.AddRange(paramList.Select(p => p.ParameterType));
-                        }
-
-                        // TODO: somehow handle generic context parameters
-                        // or more likely, just ignore it for this and do generics elsewhere
-                    }
-
-                    Helpers.DAssert(thisPos >= 0);
-                    Helpers.DAssert(retBufPos >= 0);
-                    Helpers.DAssert(argOffset >= 0);
-
-                    using (var dmd = new DynamicMethodDefinition(
-                        DebugFormatter.Format($"Glue:AbiFixup<{from},{to}>"),
-                        newRetType, argTypes.ToArray()
-                    ))
-                    {
-                        // TODO: make DMD apply attributes to the generated DynamicMethod, when possible
-                        dmd.Definition!.ImplAttributes |= Mono.Cecil.MethodImplAttributes.NoInlining |
-                            (Mono.Cecil.MethodImplAttributes)(int)MethodImplOptionsEx.AggressiveOptimization;
-
-                        var il = dmd.GetILProcessor();
-
-                        // load return buffer
-                        il.Emit(OpCodes.Ldarg, retBufPos);
-
-                        // load thisptr
-                        il.Emit(OpCodes.Ldarg, thisPos);
-
-                        // load user arguments
-                        for (var i = 0; i < paramList.Length; i++)
-                        {
-                            il.Emit(OpCodes.Ldarg, i + argOffset);
-                        }
-
-                        // call the target method
-                        il.Emit(OpCodes.Call, il.Body.Method.Module.ImportReference(to));
-
-                        // store the returned object
-                        il.Emit(OpCodes.Stobj, il.Body.Method.Module.ImportReference(retType));
-
-                        // if we need to return the pointer, do that
-                        if (Abi.ReturnsReturnBuffer)
-                        {
-                            il.Emit(OpCodes.Ldarg, retBufPos);
-                        }
-
-                        // then we're done
-                        il.Emit(OpCodes.Ret);
-
-                        return dmd.Generate();
-                    }
-                }
+                // `from` and `to` are considered compatible at this point.
+                // Thus, no ABI fixups are needed, return `to` as is.
+                return to;
             }
 
-            return to;
+            var returnBufferType = hasReturnBuffer ? returnType.MakeByRefType() : returnType;
+            var newReturnType = hasReturnBuffer && !Abi.ReturnsReturnBuffer ? typeof(void) : returnBufferType;
+
+            var thisPos = -1;
+            var returnBufferPos = -1;
+            var userArgumentsOffset = -1;
+            var parameters = from.GetParameters();
+            var argumentTypes = new List<Type>(parameters.Length + 3);
+            var argumentKinds = Abi.ArgumentOrder.Span;
+            for (var i = 0; i < argumentKinds.Length; i++)
+            {
+                switch (argumentKinds[i])
+                {
+                    case SpecialArgumentKind.ThisPointer when hasThis:
+                        thisPos = argumentTypes.Count;
+                        argumentTypes.Add(from.GetThisParamType());
+                        break;
+
+                    case SpecialArgumentKind.ReturnBuffer when hasReturnBuffer:
+                        returnBufferPos = argumentTypes.Count;
+                        argumentTypes.Add(returnBufferType);
+                        break;
+
+                    case SpecialArgumentKind.UserArguments:
+                        userArgumentsOffset = argumentTypes.Count;
+                        argumentTypes.AddRange(parameters.Select(static p => p.ParameterType));
+                        break;
+                }
+
+                // TODO: somehow handle generic context parameters
+                // or more likely, just ignore it for this and do generics elsewhere
+            }
+
+            Helpers.DAssert(thisPos >= 0 || !hasThis);
+            Helpers.DAssert(returnBufferPos >= 0 || !hasReturnBuffer);
+            Helpers.DAssert(userArgumentsOffset >= 0);
+
+            using var dmd = new DynamicMethodDefinition(
+                DebugFormatter.Format($"Glue:AbiFixup<{from},{to}>"),
+                newReturnType, argumentTypes.ToArray()
+            );
+            // TODO: make DMD apply attributes to the generated DynamicMethod, when possible
+            dmd.Definition!.ImplAttributes |= Mono.Cecil.MethodImplAttributes.NoInlining |
+                (Mono.Cecil.MethodImplAttributes)(int)MethodImplOptionsEx.AggressiveOptimization;
+
+            var il = dmd.GetILProcessor();
+
+            // load return buffer
+            if (hasReturnBuffer)
+                il.Emit(OpCodes.Ldarg, returnBufferPos);
+
+            // load thisptr
+            if (hasThis)
+                il.Emit(OpCodes.Ldarg, thisPos);
+
+            // load user arguments
+            for (var i = 0; i < parameters.Length; i++)
+                il.Emit(OpCodes.Ldarg, i + userArgumentsOffset);
+
+            // call the target method
+            il.Emit(OpCodes.Call, il.Body.Method.Module.ImportReference(to));
+
+            // store the returned object
+            if (hasReturnBuffer)
+                il.Emit(OpCodes.Stobj, il.Body.Method.Module.ImportReference(returnType));
+
+            // if we need to return the pointer, do that
+            if (hasReturnBuffer && Abi.ReturnsReturnBuffer)
+                il.Emit(OpCodes.Ldarg, returnBufferPos);
+
+            // then we're done
+            il.Emit(OpCodes.Ret);
+
+            return dmd.Generate();
         }
     }
 }

--- a/src/MonoMod.Core/Platforms/PlatformTriple.cs
+++ b/src/MonoMod.Core/Platforms/PlatformTriple.cs
@@ -686,7 +686,7 @@ namespace MonoMod.Core.Platforms
             // Consequently, there is no need for a fixup for ABIs that declare `GenericContext`
             // **after** `UserArguments`. However, as far as I know, this is only relevant for
             // RyuJITx86, so there is no value in optimizing for that scenario.
-            var requiresGenericContextFixup = HasGenericContext(Abi) && RequiresGenericContext(fromInfo);
+            var requiresGenericContextFixup = HasGenericContext(Abi) && Runtime.RequiresGenericContext(fromInfo);
 
             // Check if a fixup is needed for the current scenario.
             if (!requiresReturnBufferFixup && !requiresGenericContextFixup)
@@ -812,51 +812,6 @@ namespace MonoMod.Core.Platforms
                     return true;
             }
             return false;
-        }
-
-        private static bool RequiresGenericContext(MethodBase method)
-        {
-            // If neither the method nor its declaring type is generic,
-            // we do not need to worry about the generic context at all.
-            var declaringType = method.DeclaringType ?? typeof(object);
-            if (!method.IsGenericMethod && !declaringType.IsGenericType)
-                return false;
-
-            // If the method itself is generic, check whether at least one
-            // of its generic arguments makes it a shared instantiation.
-            var methodGenericArguments = method.IsGenericMethod ? method.GetGenericArguments() : Type.EmptyTypes;
-            if (methodGenericArguments.Any(static x => !x.IsValueType))
-                return true;
-
-            // If the method is effectively generic (i.e., it is defined on a generic type),
-            // we need to determine whether it still requires a hidden argument in the form
-            // of a MethodDesc, MethodTable, or TypeHandle pointer, or if `this` alone will
-            // suffice for this purpose.
-            //
-            // The rules are as follows:
-            //  - If both the method and its declaring type are generic, `this` alone cannot
-            //    provide the generic context the VM needs. In such cases,
-            //    we require a hidden argument for shared instantiations.
-            //  - If the method is static, there is obviously no `this` from which
-            //    the VM could infer the generic context.
-            //  - If `this` is a value type, the unboxed `this` pointer, by definition,
-            //    does not have an associated MethodTable pointer.
-            //  - If the method is a default interface method called via interface dispatch,
-            //    the VM cannot use `this` to derive the generic context because it is too
-            //    ambiguous (e.g., it may implement multiple IFoo<T> interfaces).
-            //
-            // See:
-            // https://github.com/dotnet/runtime/blob/55eee324653e01cf28809d02b25a5b0894b58d22/src/coreclr/vm/method.cpp#L1649
-            var mayNeedHiddenArg = method.IsGenericMethod
-                || method.IsStatic
-                || declaringType.IsValueType
-                || declaringType.IsInterface && !method.IsAbstract;
-            if (!mayNeedHiddenArg)
-                return false;
-
-            // Finally, check whether the type on which the method is defined may be shared.
-            var typeGenericArguments = declaringType.IsGenericType ? declaringType.GetGenericArguments() : Type.EmptyTypes;
-            return typeGenericArguments.Any(static x => !x.IsValueType);
         }
     }
 }

--- a/src/MonoMod.Core/Platforms/Runtimes/MonoRuntime.cs
+++ b/src/MonoMod.Core/Platforms/Runtimes/MonoRuntime.cs
@@ -1,4 +1,4 @@
-﻿using MonoMod.Backports;
+using MonoMod.Backports;
 using MonoMod.Utils;
 using System;
 using System.Collections.Concurrent;
@@ -226,6 +226,12 @@ namespace MonoMod.Core.Platforms.Runtimes
             }
 
             return method.MethodHandle;
+        }
+
+        public bool RequiresGenericContext(MethodBase method)
+        {
+            // Mono never provides generic context through a hidden argument.
+            return false;
         }
 
         private sealed class PrivateMethodPin

--- a/src/MonoMod.RuntimeDetour/Hook.cs
+++ b/src/MonoMod.RuntimeDetour/Hook.cs
@@ -588,6 +588,8 @@ namespace MonoMod.RuntimeDetour
 
         private MethodInfo PrepareRealTarget(object? target, out TrampolineData trampoline, out DataScope<DynamicReferenceCell> scope)
         {
+            CheckSupported();
+
             var srcSig = MethodSignature.ForMethod(Source);
             var dstSig = MethodSignature.ForMethod(Target, ignoreThis: true); // the dest sig we don't want to consider its this param
 
@@ -700,6 +702,12 @@ namespace MonoMod.RuntimeDetour
 
                 return dmd.Generate();
             }
+        }
+
+        private void CheckSupported()
+        {
+            if (Source.IsGenericMethod || Source.DeclaringType is { IsGenericType: true })
+                throw new ArgumentException("Source method is generic, generic hooks are not supported");
         }
 
         private void CheckDisposed()


### PR DESCRIPTION
### Description

Currently, if you attempt to inject into a generic method while using .NET, the injection itself works, but the hook often receives incorrect arguments. This issue arises because .NET passes a generic context to some generic methods in the form of `MethodDesc`/`MethodTable`/`TypeHandle`, which shifts all user arguments by one position.

`MonoMod` already supports the concept of "ABI fixups," so I resolved the issue by implementing a new ABI fixup rule for these scenarios. This rule disregards the provided context, similarly to how it's currently done in the Mono realm. In Mono, the `r10` register is used instead of the hidden argument for this purpose, so it doesn't create such a problem, and we can implicitly ignore its existence.

While this fix does not alter the official stance that "MonoMod doesn't support generics," it allows generics to function in .NET under conditions where they already somewhat work in Mono. Thus, this can be considered a parity feature :)

### Examples

Starting with .NET 5, all the following methods are now injectable:

```csharp
public class Foo
{
    public static void StaticMethod<T>(T t);

    public void InstanceMethod<T>(T t);
}

public class Bar<T>
{
    public static void StaticMethod(T t);

    public void InstanceMethod(T t);

    public static void StaticMethod2<U>(T t, U u);

    public void InstanceMethod2<U>(T t, U u);
}

public struct Baz
{
    public static void StaticMethod<T>(T t);

    public void InstanceMethod<T>(T t);
}

public struct Qux<T>
{
    public static void StaticMethod(T t);

    public void InstanceMethod(T t);

    public static void StaticMethod2<U>(T t, U u);

    public void InstanceMethod2<U>(T t, U u);
}
```

However, since this PR does not aim to address deeper issues, some existing problems still persist. For instance, certain injections fail to work on Windows *(though they function perfectly on Linux and macOS)* because MonoMod silently fails to apply them. Here are some scenarios I have identified:

```csharp
public void InstanceVoid<T>(List<T> list, T item, ref bool injected);

public string InstanceRegister<T>(List<T> list, T item, ref bool injected);

public LargeStruct InstanceByRef<T>(List<T> list, T item, ref bool injected);

public static LargeStruct StaticByRef<T>(List<T> list, T item, ref bool injected);
```

Thankfully, most common use cases "just work" now. And honestly, it's super useful when they do!

### Notes

Fixes #185