### PR TITLE
Avoid mutating `Instruction` instances during emit

### DIFF
--- a/src/MonoMod.UnitTest/DynamicMethodDefinitionTest.cs
+++ b/src/MonoMod.UnitTest/DynamicMethodDefinitionTest.cs
@@ -1,4 +1,6 @@
 ﻿extern alias New;
+
+using Mono.Cecil.Cil;
 using MonoMod.Cil;
 using MonoMod.Core.Platforms;
 using MonoMod.Utils;
@@ -246,6 +248,22 @@ namespace MonoMod.UnitTest
         private static int TargetTest<TA, TB>()
         {
             return 2;
+        }
+
+        [Fact]
+        public void DMDGenerateDoesNotModifyDMD()
+        {
+            using var origDmd = new DynamicMethodDefinition("Test DMD", null, []);
+            var il = origDmd.GetILProcessor();
+            var targetIns = Instruction.Create(OpCodes.Ret);
+            il.Emit(OpCodes.Br_S, targetIns);
+            il.Append(targetIns);
+
+            using var genClone = new DynamicMethodDefinition(origDmd);
+            _ = genClone.Generate();
+
+            Assert.Equal(genClone.Definition.Body.Instructions[1], genClone.Definition.Body.Instructions[0].Operand);
+            Assert.Equal(OpCodes.Br_S, genClone.Definition.Body.Instructions[0].OpCode);
         }
 
     }


### PR DESCRIPTION
Due to 6b8dc347e5aba728a852bca04c0c9e2ac6f5b46c, we can now emit actual IL for a DMD before `ILHook`s have a chance to look at it. Even though we're using different DMDs, we end up copying the already-modified DMD instead of the original, and this can break some existing code that relies on matching short-forms.