### PR TITLE
Fix CecilILGenerator declare local throwing in .NET 9

### DIFF
--- a/src/MonoMod.UnitTest/CecilIlGeneratorTest.cs
+++ b/src/MonoMod.UnitTest/CecilIlGeneratorTest.cs
@@ -1,0 +1,73 @@
+﻿using Mono.Cecil;
+using MonoMod.Utils.Cil;
+using System;
+using System.IO;
+using System.Reflection;
+using System.Reflection.Emit;
+using Xunit;
+using Xunit.Abstractions;
+using MethodAttributes = Mono.Cecil.MethodAttributes;
+using TypeAttributes = Mono.Cecil.TypeAttributes;
+
+namespace MonoMod.UnitTest
+{
+    public class CecilIlGeneratorTest : TestBase
+    {
+        public CecilIlGeneratorTest(ITestOutputHelper helper) : base(helper)
+        {
+        }
+
+        [Fact]
+        public void TestLocalEmit()
+        {
+            using var moduleStream = new MemoryStream();
+            using (var moduleDef = ModuleDefinition.CreateModule("TestModule", ModuleKind.Dll))
+            {
+                var methodDef = new MethodDefinition("TestMethod",
+                    MethodAttributes.Public | MethodAttributes.HideBySig | MethodAttributes.Static,
+                    moduleDef.TypeSystem.String);
+
+                moduleDef.Types.Add(new TypeDefinition("Test", "TestType",
+                    TypeAttributes.Public | TypeAttributes.AutoClass | TypeAttributes.AnsiClass |
+                    TypeAttributes.BeforeFieldInit)
+                {
+                    Methods = { methodDef },
+                    BaseType = moduleDef.TypeSystem.Object
+                });
+
+                methodDef.Parameters.Add(new ParameterDefinition(moduleDef.TypeSystem.Boolean));
+
+                {
+                    var il = new CecilILGenerator(methodDef.Body.GetILProcessor()).GetProxy();
+
+                    var local = il.DeclareLocal(typeof(string));
+                    
+                    il.Emit(OpCodes.Ldarga_S, 0);
+                    var toStringMethod = typeof(bool).GetMethod(nameof(bool.ToString), []);
+                    
+                    Assert.NotNull(toStringMethod);
+                    
+                    il.Emit(OpCodes.Callvirt, toStringMethod);
+                    il.Emit(OpCodes.Stloc, local);
+
+                    il.Emit(OpCodes.Ldloc, local);
+                    il.Emit(OpCodes.Ret);
+                }
+
+                moduleDef.Write(moduleStream);
+            }
+            
+            var assembly = Assembly.Load(moduleStream.ToArray());
+            
+            var type = assembly.GetType("Test.TestType");
+            
+            Assert.NotNull(type);
+            
+            var method = type.GetMethod("TestMethod");
+            
+            Assert.NotNull(method);
+            Assert.Equal(bool.TrueString, method.Invoke(null, new object[] { true }));
+            Assert.Equal(bool.FalseString, method.Invoke(null, new object[] { false }));
+        }
+    }
+}

--- a/src/MonoMod.Utils/Cil/CecilILGenerator.cs
+++ b/src/MonoMod.Utils/Cil/CecilILGenerator.cs
@@ -19,18 +19,22 @@ namespace MonoMod.Utils.Cil
     /// </summary>
     public sealed class CecilILGenerator : ILGeneratorShim
     {
+        // https://github.com/dotnet/runtime/blob/f1332ab0d82ee0e21ca387cbd1c8a87c5dfa4906/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/RuntimeLocalBuilder.cs
+        // In .NET 9 LocalBuilder is opaque type so look for RuntimeLocalBuilder first
+        private static readonly Type t_LocalBuilder = Type.GetType("System.Reflection.Emit.RuntimeLocalBuilder") ?? typeof(LocalBuilder);
+        
         // https://github.com/Unity-Technologies/mono/blob/unity-5.6/mcs/class/corlib/System.Reflection.Emit/LocalBuilder.cs
         // https://github.com/Unity-Technologies/mono/blob/unity-2018.3-mbe/mcs/class/corlib/System.Reflection.Emit/LocalBuilder.cs
         // https://github.com/dotnet/coreclr/blob/master/src/System.Private.CoreLib/src/System/Reflection/Emit/LocalBuilder.cs
         // Mono: Type, ILGenerator
         // .NET Framework matches .NET Core: int, Type, MethodInfo(, bool)
         private static readonly ConstructorInfo c_LocalBuilder =
-            typeof(LocalBuilder).GetConstructors(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance)
+            t_LocalBuilder.GetConstructors(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance)
             .OrderByDescending(c => c.GetParameters().Length).First();
         private static readonly FieldInfo? f_LocalBuilder_position =
-            typeof(LocalBuilder).GetField("position", BindingFlags.NonPublic | BindingFlags.Instance);
+            t_LocalBuilder.GetField("position", BindingFlags.NonPublic | BindingFlags.Instance);
         private static readonly FieldInfo? f_LocalBuilder_is_pinned =
-            typeof(LocalBuilder).GetField("is_pinned", BindingFlags.NonPublic | BindingFlags.Instance);
+            t_LocalBuilder.GetField("is_pinned", BindingFlags.NonPublic | BindingFlags.Instance);
 
         private static int c_LocalBuilder_params = c_LocalBuilder.GetParameters().Length;
 


### PR DESCRIPTION
LocalBuilder was made opaque in .NET 9 and separated into RuntimeLocalBuilder type. This PR allows reflection access to lookup RuntimeLocalBuilder before falling back to just LocalBuilder. Also i added a unit test for that case.

Exception for reference.
```
System.MemberAccessException : Cannot create an instance of System.Reflection.Emit.LocalBuilder because it is an abstract class.

```

