### PR TITLE
One-character null reference fix

### DIFF
--- a/src/MonoMod.Utils/ReflectionHelper.cs
+++ b/src/MonoMod.Utils/ReflectionHelper.cs
@@ -128,7 +128,7 @@ namespace MonoMod.Utils
                 return asm.FullName;
 
             var hash = asm.Hash;
-            if (hash.Length != AssemblyHashPrefix.Length + 4)
+            if (hash?.Length != AssemblyHashPrefix.Length + 4)
                 return asm.FullName;
 
             for (var i = 0; i < AssemblyHashPrefix.Length; i++)


### PR DESCRIPTION
When trying to build an ILHook, I get an exception during the 'DynamicMethodDefinition.Generate' method. It turns out that reflection helpers.GetRuntimeHashedFullName() is being passed an  AssemblyNameReference object with a hash algorithm, yet the hash property is null.

Looking at the definition of AssemblyNameReference in Mono.Cecil, the hash object is not necessarily set in the constructor, so it seems reasonable to assume that it may be null.

After I made this one character fix, my ILHook started to work exactly as expected.