### PR TITLE
Properly handle floating point returns in Windows x86

### DIFF
--- a/.github/workflows/test_results.yml
+++ b/.github/workflows/test_results.yml
@@ -16,7 +16,7 @@ jobs:
     permissions:
       checks: write
       pull-requests: write
-      contents: read
+      contents: write
       issues: read
       actions: read
       statuses: read

--- a/.gitignore
+++ b/.gitignore
@@ -236,3 +236,4 @@ ModelManifest.xml
 *.dump
 
 .mono/
+.aider*

--- a/src/MonoMod.Core/Platforms/PlatformTriple.cs
+++ b/src/MonoMod.Core/Platforms/PlatformTriple.cs
@@ -733,7 +733,7 @@ namespace MonoMod.Core.Platforms
                         //     => typeof(T).IsAssignableFrom(it.GetType());
                         //
                         // This behavior is caused by the fact that constructed
-                        // generics for reference types are Javad into a single
+                        // generics for reference types are Java'd into a single
                         // definition at runtime (and rightfully so).
                         // So, even if you try to detour a specific generic
                         // implementation using something like

--- a/src/MonoMod.Core/Platforms/PlatformTriple.cs
+++ b/src/MonoMod.Core/Platforms/PlatformTriple.cs
@@ -659,18 +659,7 @@ namespace MonoMod.Core.Platforms
             var returnType = fromInfo.ReturnType;
             var hasReturnBuffer = Abi.Classify(returnType, true) is TypeClassification.ByReference;
             var hasThis = !fromInfo.IsStatic;
-            
-            // Special handling for x86 platform
-            var isX86Platform = Environment.OSVersion.Platform == PlatformID.Win32NT && 
-                                IntPtr.Size == 4;
-            
-            // On x86, we need special handling for instance-to-static method transitions
-            // regardless of whether there's a return buffer
-            var requiresReturnBufferFixup = hasThis && toInfo.IsStatic && 
-                                           (hasReturnBuffer && !isX86Platform);
-            
-            // For x86, we'll handle the instance-to-static transition in a different way
-            var requiresX86InstanceFixup = isX86Platform && hasThis && toInfo.IsStatic;
+            var requiresReturnBufferFixup = hasThis && toInfo.IsStatic && hasReturnBuffer;
 
             // Whenever we detour a call from a generic method, depending on the ABI, we may
             // receive a generic context as an argument, which a callee never needs, at least
@@ -700,7 +689,7 @@ namespace MonoMod.Core.Platforms
             var requiresGenericContextFixup = HasGenericContext(Abi) && Runtime.RequiresGenericContext(fromInfo);
 
             // Check if a fixup is needed for the current scenario.
-            if (!requiresReturnBufferFixup && !requiresGenericContextFixup && !requiresX86InstanceFixup)
+            if (!requiresReturnBufferFixup && !requiresGenericContextFixup)
             {
                 // `from` and `to` are considered compatible at this point.
                 // Thus, no ABI fixups are needed, return `to` as is.
@@ -715,78 +704,59 @@ namespace MonoMod.Core.Platforms
             var userArgumentsOffset = -1;
             var parameters = from.GetParameters();
             var argumentTypes = new List<Type>(parameters.Length + 3);
-            
-            // For x86 platform, we need to handle the argument order differently
-            if (requiresX86InstanceFixup)
+            var argumentKinds = Abi.ArgumentOrder.Span;
+            for (var i = 0; i < argumentKinds.Length; i++)
             {
-                // On x86, the order is always: this, return buffer, user arguments
-                // This matches the x86 calling convention described in the docs
-                thisPos = 0;
-                argumentTypes.Add(from.GetThisParamType());
-                
-                returnBufferPos = 1;
-                argumentTypes.Add(returnBufferType);
-                
-                userArgumentsOffset = 2;
-                argumentTypes.AddRange(parameters.Select(p => p.ParameterType));
-            }
-            else
-            {
-                // For other platforms, use the ABI-defined argument order
-                var argumentKinds = Abi.ArgumentOrder.Span;
-                for (var i = 0; i < argumentKinds.Length; i++)
+                switch (argumentKinds[i])
                 {
-                    switch (argumentKinds[i])
-                    {
-                        case SpecialArgumentKind.ThisPointer when hasThis:
-                            thisPos = argumentTypes.Count;
-                            argumentTypes.Add(from.GetThisParamType());
-                            break;
+                    case SpecialArgumentKind.ThisPointer when hasThis:
+                        thisPos = argumentTypes.Count;
+                        argumentTypes.Add(from.GetThisParamType());
+                        break;
 
-                        case SpecialArgumentKind.ReturnBuffer when hasReturnBuffer:
-                            returnBufferPos = argumentTypes.Count;
-                            argumentTypes.Add(returnBufferType);
-                            break;
+                    case SpecialArgumentKind.ReturnBuffer when hasReturnBuffer:
+                        returnBufferPos = argumentTypes.Count;
+                        argumentTypes.Add(returnBufferType);
+                        break;
 
-                        case SpecialArgumentKind.GenericContext when requiresGenericContextFixup:
-                            // Currently, we do the bare minimum: we acknowledge that
-                            // the generic context exists. That's all. After that,
-                            // we simply throw it out of the window and rely on
-                            // the generic context (if any) baked into in the callee.
-                            //
-                            // While this does work fine, it introduces funny little
-                            // holes in the type-safety premise of .NET:
-                            //
-                            // // This may return `false`!
-                            // bool Hook<T>(T it)
-                            //     => typeof(T).IsAssignableFrom(it.GetType());
-                            //
-                            // This behavior is caused by the fact that constructed
-                            // generics for reference types are Java'd into a single
-                            // definition at runtime (and rightfully so).
-                            // So, even if you try to detour a specific generic
-                            // implementation using something like
-                            // `to.MakeGenericMethod(typeof(string))`,
-                            // your hook will receive calls for all
-                            // reference type-based implementations out there.
-                            // However, since we do not patch the generic context
-                            // of the provided hook, it remains unchanged,
-                            // causing `typeof(T)` to defy users' expectations.
-                            //
-                            // So, TODO: patch the generic context of the detour target
-                            // and/or introduce a call filter based on the current context.
+                    case SpecialArgumentKind.GenericContext when requiresGenericContextFixup:
+                        // Currently, we do the bare minimum: we acknowledge that
+                        // the generic context exists. That's all. After that,
+                        // we simply throw it out of the window and rely on
+                        // the generic context (if any) baked into in the callee.
+                        //
+                        // While this does work fine, it introduces funny little
+                        // holes in the type-safety premise of .NET:
+                        //
+                        // // This may return `false`!
+                        // bool Hook<T>(T it)
+                        //     => typeof(T).IsAssignableFrom(it.GetType());
+                        //
+                        // This behavior is caused by the fact that constructed
+                        // generics for reference types are Java'd into a single
+                        // definition at runtime (and rightfully so).
+                        // So, even if you try to detour a specific generic
+                        // implementation using something like
+                        // `to.MakeGenericMethod(typeof(string))`,
+                        // your hook will receive calls for all
+                        // reference type-based implementations out there.
+                        // However, since we do not patch the generic context
+                        // of the provided hook, it remains unchanged,
+                        // causing `typeof(T)` to defy users' expectations.
+                        //
+                        // So, TODO: patch the generic context of the detour target
+                        // and/or introduce a call filter based on the current context.
 
-                            // The generic context is passed as a pointer to a struct that
-                            // contains all the needed (?) information.
-                            // We can treat it as a simple `IntPtr`.
-                            argumentTypes.Add(typeof(nint));
-                            break;
+                        // The generic context is passed as a pointer to a struct that
+                        // contains all the needed (?) information.
+                        // We can treat it as a simple `IntPtr`.
+                        argumentTypes.Add(typeof(nint));
+                        break;
 
-                        case SpecialArgumentKind.UserArguments:
-                            userArgumentsOffset = argumentTypes.Count;
-                            argumentTypes.AddRange(parameters.Select(static p => p.ParameterType));
-                            break;
-                    }
+                    case SpecialArgumentKind.UserArguments:
+                        userArgumentsOffset = argumentTypes.Count;
+                        argumentTypes.AddRange(parameters.Select(static p => p.ParameterType));
+                        break;
                 }
             }
 

--- a/src/MonoMod.Core/Platforms/PlatformTriple.cs
+++ b/src/MonoMod.Core/Platforms/PlatformTriple.cs
@@ -659,7 +659,18 @@ namespace MonoMod.Core.Platforms
             var returnType = fromInfo.ReturnType;
             var hasReturnBuffer = Abi.Classify(returnType, true) is TypeClassification.ByReference;
             var hasThis = !fromInfo.IsStatic;
-            var requiresReturnBufferFixup = hasThis && toInfo.IsStatic && hasReturnBuffer;
+            
+            // Special handling for x86 platform
+            var isX86Platform = Environment.OSVersion.Platform == PlatformID.Win32NT && 
+                                IntPtr.Size == 4;
+            
+            // On x86, we need special handling for instance-to-static method transitions
+            // regardless of whether there's a return buffer
+            var requiresReturnBufferFixup = hasThis && toInfo.IsStatic && 
+                                           (hasReturnBuffer && !isX86Platform);
+            
+            // For x86, we'll handle the instance-to-static transition in a different way
+            var requiresX86InstanceFixup = isX86Platform && hasThis && toInfo.IsStatic;
 
             // Whenever we detour a call from a generic method, depending on the ABI, we may
             // receive a generic context as an argument, which a callee never needs, at least
@@ -689,7 +700,7 @@ namespace MonoMod.Core.Platforms
             var requiresGenericContextFixup = HasGenericContext(Abi) && Runtime.RequiresGenericContext(fromInfo);
 
             // Check if a fixup is needed for the current scenario.
-            if (!requiresReturnBufferFixup && !requiresGenericContextFixup)
+            if (!requiresReturnBufferFixup && !requiresGenericContextFixup && !requiresX86InstanceFixup)
             {
                 // `from` and `to` are considered compatible at this point.
                 // Thus, no ABI fixups are needed, return `to` as is.
@@ -704,59 +715,78 @@ namespace MonoMod.Core.Platforms
             var userArgumentsOffset = -1;
             var parameters = from.GetParameters();
             var argumentTypes = new List<Type>(parameters.Length + 3);
-            var argumentKinds = Abi.ArgumentOrder.Span;
-            for (var i = 0; i < argumentKinds.Length; i++)
+            
+            // For x86 platform, we need to handle the argument order differently
+            if (requiresX86InstanceFixup)
             {
-                switch (argumentKinds[i])
+                // On x86, the order is always: this, return buffer, user arguments
+                // This matches the x86 calling convention described in the docs
+                thisPos = 0;
+                argumentTypes.Add(from.GetThisParamType());
+                
+                returnBufferPos = 1;
+                argumentTypes.Add(returnBufferType);
+                
+                userArgumentsOffset = 2;
+                argumentTypes.AddRange(parameters.Select(p => p.ParameterType));
+            }
+            else
+            {
+                // For other platforms, use the ABI-defined argument order
+                var argumentKinds = Abi.ArgumentOrder.Span;
+                for (var i = 0; i < argumentKinds.Length; i++)
                 {
-                    case SpecialArgumentKind.ThisPointer when hasThis:
-                        thisPos = argumentTypes.Count;
-                        argumentTypes.Add(from.GetThisParamType());
-                        break;
+                    switch (argumentKinds[i])
+                    {
+                        case SpecialArgumentKind.ThisPointer when hasThis:
+                            thisPos = argumentTypes.Count;
+                            argumentTypes.Add(from.GetThisParamType());
+                            break;
 
-                    case SpecialArgumentKind.ReturnBuffer when hasReturnBuffer:
-                        returnBufferPos = argumentTypes.Count;
-                        argumentTypes.Add(returnBufferType);
-                        break;
+                        case SpecialArgumentKind.ReturnBuffer when hasReturnBuffer:
+                            returnBufferPos = argumentTypes.Count;
+                            argumentTypes.Add(returnBufferType);
+                            break;
 
-                    case SpecialArgumentKind.GenericContext when requiresGenericContextFixup:
-                        // Currently, we do the bare minimum: we acknowledge that
-                        // the generic context exists. That's all. After that,
-                        // we simply throw it out of the window and rely on
-                        // the generic context (if any) baked into in the callee.
-                        //
-                        // While this does work fine, it introduces funny little
-                        // holes in the type-safety premise of .NET:
-                        //
-                        // // This may return `false`!
-                        // bool Hook<T>(T it)
-                        //     => typeof(T).IsAssignableFrom(it.GetType());
-                        //
-                        // This behavior is caused by the fact that constructed
-                        // generics for reference types are Java'd into a single
-                        // definition at runtime (and rightfully so).
-                        // So, even if you try to detour a specific generic
-                        // implementation using something like
-                        // `to.MakeGenericMethod(typeof(string))`,
-                        // your hook will receive calls for all
-                        // reference type-based implementations out there.
-                        // However, since we do not patch the generic context
-                        // of the provided hook, it remains unchanged,
-                        // causing `typeof(T)` to defy users' expectations.
-                        //
-                        // So, TODO: patch the generic context of the detour target
-                        // and/or introduce a call filter based on the current context.
+                        case SpecialArgumentKind.GenericContext when requiresGenericContextFixup:
+                            // Currently, we do the bare minimum: we acknowledge that
+                            // the generic context exists. That's all. After that,
+                            // we simply throw it out of the window and rely on
+                            // the generic context (if any) baked into in the callee.
+                            //
+                            // While this does work fine, it introduces funny little
+                            // holes in the type-safety premise of .NET:
+                            //
+                            // // This may return `false`!
+                            // bool Hook<T>(T it)
+                            //     => typeof(T).IsAssignableFrom(it.GetType());
+                            //
+                            // This behavior is caused by the fact that constructed
+                            // generics for reference types are Java'd into a single
+                            // definition at runtime (and rightfully so).
+                            // So, even if you try to detour a specific generic
+                            // implementation using something like
+                            // `to.MakeGenericMethod(typeof(string))`,
+                            // your hook will receive calls for all
+                            // reference type-based implementations out there.
+                            // However, since we do not patch the generic context
+                            // of the provided hook, it remains unchanged,
+                            // causing `typeof(T)` to defy users' expectations.
+                            //
+                            // So, TODO: patch the generic context of the detour target
+                            // and/or introduce a call filter based on the current context.
 
-                        // The generic context is passed as a pointer to a struct that
-                        // contains all the needed (?) information.
-                        // We can treat it as a simple `IntPtr`.
-                        argumentTypes.Add(typeof(nint));
-                        break;
+                            // The generic context is passed as a pointer to a struct that
+                            // contains all the needed (?) information.
+                            // We can treat it as a simple `IntPtr`.
+                            argumentTypes.Add(typeof(nint));
+                            break;
 
-                    case SpecialArgumentKind.UserArguments:
-                        userArgumentsOffset = argumentTypes.Count;
-                        argumentTypes.AddRange(parameters.Select(static p => p.ParameterType));
-                        break;
+                        case SpecialArgumentKind.UserArguments:
+                            userArgumentsOffset = argumentTypes.Count;
+                            argumentTypes.AddRange(parameters.Select(static p => p.ParameterType));
+                            break;
+                    }
                 }
             }
 

--- a/src/MonoMod.Core/Platforms/Runtimes/FxCoreBaseRuntime.cs
+++ b/src/MonoMod.Core/Platforms/Runtimes/FxCoreBaseRuntime.cs
@@ -29,7 +29,6 @@ namespace MonoMod.Core.Platforms.Runtimes
 
         private static TypeClassification ClassifyRyuJitX86(Type type, bool isReturn)
         {
-
             while (!type.IsPrimitive || type.IsEnum)
             {
                 var fields = type.GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);

--- a/src/MonoMod.Core/Platforms/Runtimes/FxCoreBaseRuntime.cs
+++ b/src/MonoMod.Core/Platforms/Runtimes/FxCoreBaseRuntime.cs
@@ -60,6 +60,12 @@ namespace MonoMod.Core.Platforms.Runtimes
                 return TypeClassification.InRegister;
             }
 
+            // if the type is floating point and we're checking return, it's returned on the FP stack
+            if (isReturn && typeCode is TypeCode.Single or TypeCode.Double)
+            {
+                return TypeClassification.InRegister;
+            }
+
             // all others are passed on stack, or in a return buffer
             if (isReturn)
             {

--- a/src/MonoMod.UnitTest/Github/Issue221.cs
+++ b/src/MonoMod.UnitTest/Github/Issue221.cs
@@ -1,0 +1,53 @@
+extern alias New;
+using New::MonoMod.RuntimeDetour;
+using System;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace MonoMod.UnitTest.Github
+{
+    public class Issue221 : TestBase
+    {
+        public Issue221(ITestOutputHelper helper) : base(helper)
+        {
+        }
+
+        private class Player
+        {
+            private float RunMaxSpeed
+            {
+                [MethodImpl(MethodImplOptions.NoInlining)]
+                get
+                {
+                    return 40;
+                }
+            }
+            public void Update()
+            {
+                Console.WriteLine("Before RunMaxSpeed");
+                if (RunMaxSpeed <= 40)
+                {
+                    Console.WriteLine("Run");
+                }
+                Console.WriteLine("After RunMaxSpeed");
+            }
+        }
+
+        [Fact]
+        public void GlueAbiFixup_HookingPrivateGetProperty_DoesNotThrow()
+        {
+            var prop = typeof(Player).GetProperty("RunMaxSpeed", BindingFlags.Instance | BindingFlags.NonPublic);
+            using var runMaxSpeed = new Hook(prop.GetGetMethod(true), RunMaxSpeed_patch);
+            var player = new Player();
+            player.Update();
+        }
+
+        private static float RunMaxSpeed_patch(Func<Player, float> orig, Player player)
+        {
+            Console.WriteLine("Go through");
+            return orig(player);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #221.

We previously didn't correctly handle floating point returns. While they're passed by-reference in parameters, they're returned on the FP stack (so a kind of register). This leads to our ABI fixup trying to use a return buffer when none is actually used.

(This PR is mostly done by AI; the issue was written by a local Llama3 instance (though fixed by me), and the fix was found/applied by Claude, though only after many attempts by me to get it to, and after I noticed the issue. Likely a skill issue on my part.)

![image](https://github.com/user-attachments/assets/532893dd-23cb-4c22-98d3-1c911b4d9b1a)
