### PR TITLE
Suppress build immediately after new release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,8 @@ jobs:
     name: Setup
     runs-on: ubuntu-latest
     outputs:
-      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+      should_skip: ${{ steps.skip_check.outputs.should_skip == 'true' || steps.msg_check.outputs.skip == 'true' }}
+      upload_pkgs: ${{ steps.msg_check.outputs.skip != 'true' }}
       skipped_by: ${{ steps.skip_check.outputs.skipped_by }}
       ver: ${{ steps.computever.outputs.ver }}
       matrix: ${{ steps.compute-matrix.outputs.matrix }}
@@ -39,6 +40,10 @@ jobs:
       with:
         cancel_others: true
         concurrent_skipping: same_content_newer
+
+    - name: Check if this run is skipped by commit message
+      id: msg_check
+      run: echo "skip=${{ github.event_name == 'push' && contains(github.event.head_commit.message, '[skip-ci]') }}" >> $env:GITHUB_OUTPUT
 
     - name: Upload event file
       uses: actions/upload-artifact@v4
@@ -52,12 +57,11 @@ jobs:
       run: echo "ver=$(Get-Date -Format y.M.d).${{ github.run_number }}.${{ github.run_attempt }}" >> $env:GITHUB_OUTPUT
 
     - name: Checkout
+      if: steps.skip_check.outputs.should_skip != 'true'
       uses: actions/checkout@v4
       with:
         lfs: false
         submodules: false
-        
-    # TODO: maybe we can eventually use package locks for package caching?
     
     - name: Install .NET SDK
       if: steps.skip_check.outputs.should_skip != 'true'
@@ -167,7 +171,7 @@ jobs:
       
   upload:
     needs: [setup, build-testassets]
-    if: ${{ github.ref_name == 'reorganize' && (success() || needs.setup.result == 'success') }}
+    if: ${{ needs.setup.upload_pkgs == 'true' && github.ref_name == 'reorganize' && (success() || needs.setup.result == 'success') }}
     name: Upload Packages
     uses: ./.github/workflows/upload-packages.yml
     with:

--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -160,7 +160,7 @@ jobs:
 
   bump-ver:
     name: Bump versions
-    needs: [upload-github, upload-nuget]
+    needs: [setup, upload-github, upload-nuget]
     if: ${{ !failure() && !cancelled() }}
     runs-on: ubuntu-latest
 
@@ -221,7 +221,10 @@ jobs:
       if: '!inputs.prerelease'
       uses: EndBug/add-and-commit@v9
       with:
-        message: "[BOT]: Bump version after ${{ needs.setup.outputs.ver }}"
+        message: |
+          [BOT]: Bump version after ${{ needs.setup.outputs.ver }} release
+
+          [skip-ci]
         default_author: github_actions
         push: ${{ !inputs.dryrun && 'origin --force --set-upstream' || 'false' }}
         pathspec_error_handling: exitAtEnd


### PR DESCRIPTION
The build doesn't matter anyway, as it just contains the release but with a bumped version number. Additionally, it fails because it cannot pull the just-pushed versions for ApiCompat.