### PR TITLE
Allow methodbuilder dmd generator for net9+

### DIFF
--- a/src/MonoMod.Utils/DMDGenerators/DMDEmit.cs
+++ b/src/MonoMod.Utils/DMDGenerators/DMDEmit.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
-#if NETFRAMEWORK
+#if METHODBUILDER_SUPPORTED
 using System.Diagnostics.SymbolStore;
 #endif
 
@@ -37,7 +37,7 @@ namespace MonoMod.Utils
         {
             var def = dmd.Definition ?? throw new InvalidOperationException();
             var dm = _mb as DynamicMethod;
-#if NETFRAMEWORK
+#if METHODBUILDER_SUPPORTED
             var mb = _mb as MethodBuilder;
             var moduleBuilder = mb?.Module as ModuleBuilder;
             // moduleBuilder.Assembly sometimes avoids the .Assembly override under mysterious circumstances.
@@ -59,7 +59,7 @@ namespace MonoMod.Utils
                     dm.DefineParameter(param.Index + 1, (System.Reflection.ParameterAttributes)param.Attributes, param.Name);
                 }
             }
-#if NETFRAMEWORK
+#if METHODBUILDER_SUPPORTED
             if (mb != null) {
                 foreach (var param in def.Parameters) {
                     mb.DefineParameter(param.Index + 1, (System.Reflection.ParameterAttributes) param.Attributes, param.Name);
@@ -71,7 +71,7 @@ namespace MonoMod.Utils
                 var =>
                 {
                     var local = il.DeclareLocal(var.VariableType.ResolveReflection(), var.IsPinned);
-#if NETFRAMEWORK && !CECIL0_9
+#if METHODBUILDER_SUPPORTED && !CECIL0_9
                     if (mb != null && defInfo != null && defInfo.TryGetName(var, out var name)) {
                         local.SetLocalSymInfo(name);
                     }
@@ -98,7 +98,7 @@ namespace MonoMod.Utils
                 }
             }
 
-#if NETFRAMEWORK
+#if METHODBUILDER_SUPPORTED
             var infoDocCache = mb == null ? null : new Dictionary<Document, ISymbolDocumentWriter>();
 #endif
 
@@ -110,7 +110,7 @@ namespace MonoMod.Utils
                 if (labelMap.TryGetValue(instr, out var label))
                     il.MarkLabel(label);
 
-#if NETFRAMEWORK
+#if METHODBUILDER_SUPPORTED
                 var instrInfo = defInfo?.GetSequencePoint(instr);
                 if (mb is not null && instrInfo is not null && infoDocCache is not null && moduleBuilder is not null) {
                     if (!infoDocCache.TryGetValue(instrInfo.Document, out var infoDoc)) {
@@ -212,7 +212,7 @@ namespace MonoMod.Utils
                     {
                         var member = mref == def ? _mb : mref.ResolveReflection();
                         operand = member;
-#if NETFRAMEWORK
+#if METHODBUILDER_SUPPORTED
                         if (mb != null && member != null) {
                             // See DMDGenerator.cs for the explanation of this forced .?
                             var module = member.Module;
@@ -223,7 +223,7 @@ namespace MonoMod.Utils
                                 // while (member.DeclaringType != null)
                                 //     member = member.DeclaringType;
                                 assemblyBuilder.SetCustomAttribute(new CustomAttributeBuilder(DynamicMethodDefinition.c_IgnoresAccessChecksToAttribute, new object[] {
-                                    asm.GetName().Name
+                                    asm.GetName().Name!
                                 }));
                                 accessChecksIgnored.Add(asm);
                             }
@@ -239,7 +239,7 @@ namespace MonoMod.Utils
                             _EmitCallSite(dm, il, _ReflOpCodes[opcode.Value], csite);
                             continue;
                         }
-#if NETFRAMEWORK
+#if METHODBUILDER_SUPPORTED
                         if (mb is not null) {
                             operand = csite.ResolveReflection(mb.Module);
                         } else
@@ -249,7 +249,7 @@ namespace MonoMod.Utils
                         }
                     }
 
-#if NETFRAMEWORK
+#if METHODBUILDER_SUPPORTED
                     if (mb != null && operand is MethodBase called && called.DeclaringType == null) {
                         // "Global" methods (f.e. DynamicMethods) cannot be tokenized.
                         if (opcode == Mono.Cecil.Cil.OpCodes.Call) {

--- a/src/MonoMod.Utils/DMDGenerators/DMDEmit.cs
+++ b/src/MonoMod.Utils/DMDGenerators/DMDEmit.cs
@@ -1,4 +1,7 @@
-﻿using Mono.Cecil;
+﻿#if NETFRAMEWORK || NET9_0_OR_GREATER
+#define METHODBUILDER_SUPPORTED
+#endif
+using Mono.Cecil;
 using Mono.Cecil.Cil;
 using MonoMod.Utils.Cil;
 using System;

--- a/src/MonoMod.Utils/DMDGenerators/DMDEmitMethodBuilderGenerator.cs
+++ b/src/MonoMod.Utils/DMDGenerators/DMDEmitMethodBuilderGenerator.cs
@@ -1,4 +1,4 @@
-﻿#if NETFRAMEWORK
+﻿#if METHODBUILDER_SUPPORTED
 using MonoMod.Logs;
 using System;
 using System.Collections.Generic;
@@ -18,21 +18,35 @@ namespace MonoMod.Utils
         {
             var typeBuilder = context as TypeBuilder;
             var method = GenerateMethodBuilder(dmd, typeBuilder);
-            typeBuilder = (TypeBuilder)method.DeclaringType;
+            typeBuilder = (TypeBuilder)method.DeclaringType!;
             var type = typeBuilder.CreateType();
             var dumpPath = Switches.TryGetSwitchValue(Switches.DMDDumpTo, out var dumpToVal) ? dumpToVal as string : null;
             if (!string.IsNullOrEmpty(dumpPath))
             {
+#if NETFRAMEWORK
                 var path = method.Module.FullyQualifiedName;
                 var name = Path.GetFileName(path);
                 var dir = Path.GetDirectoryName(path);
+#else
+                var dir = Path.GetFullPath(dumpPath);
+                var path = Path.Combine(dir, method.Module.ScopeName);
+#endif
                 if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
                     Directory.CreateDirectory(dir);
                 if (File.Exists(path))
                     File.Delete(path);
+
+#if NETFRAMEWORK
                 ((AssemblyBuilder)typeBuilder.Assembly).Save(name);
+#elif NET9_0_OR_GREATER
+                using var stream = new FileStream(path, FileMode.Create, FileAccess.ReadWrite);
+                ((PersistedAssemblyBuilder)typeBuilder.Assembly).Save(stream);
+                stream.Seek(0, SeekOrigin.Begin);
+                type = ReflectionHelper.Load(stream).GetType(typeBuilder.FullName!, true, false)!;
+#endif
             }
-            return type.GetMethod(method.Name, BindingFlags.DeclaredOnly | BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static);
+            return type.GetMethod(method.Name, BindingFlags.DeclaredOnly | BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static)
+                ?? throw new InvalidOperationException("Could not find generated method");
         }
 
         public static MethodBuilder GenerateMethodBuilder(DynamicMethodDefinition dmd, TypeBuilder? typeBuilder)
@@ -43,7 +57,9 @@ namespace MonoMod.Utils
 
             if (typeBuilder == null)
             {
+                AssemblyBuilder ab;
                 var dumpDir = Switches.TryGetSwitchValue(Switches.DMDDumpTo, out var dumpToVal) ? dumpToVal as string : null;
+#if NETFRAMEWORK
                 if (string.IsNullOrEmpty(dumpDir))
                 {
                     dumpDir = null;
@@ -53,7 +69,7 @@ namespace MonoMod.Utils
                     dumpDir = Path.GetFullPath(dumpDir);
                 }
                 var collect = string.IsNullOrEmpty(dumpDir) && _MBCanRunAndCollect;
-                var ab = AppDomain.CurrentDomain.DefineDynamicAssembly(
+                ab = AppDomain.CurrentDomain.DefineDynamicAssembly(
                     new AssemblyName()
                     {
                         Name = dmd.GetDumpName("MethodBuilder")
@@ -61,6 +77,28 @@ namespace MonoMod.Utils
                     collect ? (AssemblyBuilderAccess)9 : AssemblyBuilderAccess.RunAndSave,
                     dumpDir
                 );
+#elif NET9_0_OR_GREATER
+                if (!string.IsNullOrEmpty(dumpDir))
+                {
+                    ab = new PersistedAssemblyBuilder(
+                        new AssemblyName()
+                        {
+                            Name = dmd.GetDumpName("MethodBuilder")
+                        },
+                        typeof(object).Assembly
+                    );
+                }
+                else
+                {
+                    ab = AssemblyBuilder.DefineDynamicAssembly(
+                        new AssemblyName()
+                        {
+                            Name = dmd.GetDumpName("MethodBuilder")
+                        },
+                        _MBCanRunAndCollect ? (AssemblyBuilderAccess)9 : AssemblyBuilderAccess.Run
+                    );
+                }
+#endif
 
                 ab.SetCustomAttribute(new CustomAttributeBuilder(DynamicMethodDefinition.c_UnverifiableCodeAttribute, []));
 
@@ -71,10 +109,14 @@ namespace MonoMod.Utils
                     ]));
                 }
 
+#if NETFRAMEWORK
                 // Note: Debugging can fail on mono if Mono.CompilerServices.SymbolWriter.dll cannot be found,
                 // or if Mono.CompilerServices.SymbolWriter.SymbolWriterImpl can't be found inside of that.
                 // https://github.com/mono/mono/blob/f879e35e3ed7496d819bd766deb8be6992d068ed/mcs/class/corlib/System.Reflection.Emit/ModuleBuilder.cs#L146
                 var module = ab.DefineDynamicModule($"{ab.GetName().Name}.dll", $"{ab.GetName().Name}.dll", dmd.Debug);
+#else
+                var module = ab.DefineDynamicModule($"{ab.GetName().Name}.dll");
+#endif
                 typeBuilder = module.DefineType(
                     DebugFormatter.Format($"DMD<{orig}>?{dmd.GetHashCode()}"),
                     System.Reflection.TypeAttributes.Public | System.Reflection.TypeAttributes.Abstract | System.Reflection.TypeAttributes.Sealed | System.Reflection.TypeAttributes.Class

--- a/src/MonoMod.Utils/DMDGenerators/DMDEmitMethodBuilderGenerator.cs
+++ b/src/MonoMod.Utils/DMDGenerators/DMDEmitMethodBuilderGenerator.cs
@@ -1,24 +1,28 @@
 ﻿#if NETFRAMEWORK
+using MonoMod.Logs;
 using System;
-using System.Reflection;
-using System.Reflection.Emit;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using MonoMod.Logs;
+using System.Reflection;
+using System.Reflection.Emit;
 
-namespace MonoMod.Utils {
-    public sealed class DMDEmitMethodBuilderGenerator : DMDGenerator<DMDEmitMethodBuilderGenerator> {
+namespace MonoMod.Utils
+{
+    public sealed class DMDEmitMethodBuilderGenerator : DMDGenerator<DMDEmitMethodBuilderGenerator>
+    {
 
         private static readonly bool _MBCanRunAndCollect = Enum.IsDefined(typeof(AssemblyBuilderAccess), "RunAndCollect");
 
-        protected override MethodInfo GenerateCore(DynamicMethodDefinition dmd, object? context) {
+        protected override MethodInfo GenerateCore(DynamicMethodDefinition dmd, object? context)
+        {
             var typeBuilder = context as TypeBuilder;
             var method = GenerateMethodBuilder(dmd, typeBuilder);
-            typeBuilder = (TypeBuilder) method.DeclaringType;
+            typeBuilder = (TypeBuilder)method.DeclaringType;
             var type = typeBuilder.CreateType();
             var dumpPath = Switches.TryGetSwitchValue(Switches.DMDDumpTo, out var dumpToVal) ? dumpToVal as string : null;
-            if (!string.IsNullOrEmpty(dumpPath)) {
+            if (!string.IsNullOrEmpty(dumpPath))
+            {
                 var path = method.Module.FullyQualifiedName;
                 var name = Path.GetFileName(path);
                 var dir = Path.GetDirectoryName(path);
@@ -26,35 +30,42 @@ namespace MonoMod.Utils {
                     Directory.CreateDirectory(dir);
                 if (File.Exists(path))
                     File.Delete(path);
-                ((AssemblyBuilder) typeBuilder.Assembly).Save(name);
+                ((AssemblyBuilder)typeBuilder.Assembly).Save(name);
             }
             return type.GetMethod(method.Name, BindingFlags.DeclaredOnly | BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static);
         }
 
-        public static MethodBuilder GenerateMethodBuilder(DynamicMethodDefinition dmd, TypeBuilder? typeBuilder) {
+        public static MethodBuilder GenerateMethodBuilder(DynamicMethodDefinition dmd, TypeBuilder? typeBuilder)
+        {
             Helpers.ThrowIfArgumentNull(dmd);
             var orig = dmd.OriginalMethod;
             var def = dmd.Definition;
 
-            if (typeBuilder == null) {
+            if (typeBuilder == null)
+            {
                 var dumpDir = Switches.TryGetSwitchValue(Switches.DMDDumpTo, out var dumpToVal) ? dumpToVal as string : null;
-                if (string.IsNullOrEmpty(dumpDir)) {
+                if (string.IsNullOrEmpty(dumpDir))
+                {
                     dumpDir = null;
-                } else {
+                }
+                else
+                {
                     dumpDir = Path.GetFullPath(dumpDir);
                 }
                 var collect = string.IsNullOrEmpty(dumpDir) && _MBCanRunAndCollect;
                 var ab = AppDomain.CurrentDomain.DefineDynamicAssembly(
-                    new AssemblyName() {
+                    new AssemblyName()
+                    {
                         Name = dmd.GetDumpName("MethodBuilder")
                     },
-                    collect ? (AssemblyBuilderAccess) 9 : AssemblyBuilderAccess.RunAndSave,
+                    collect ? (AssemblyBuilderAccess)9 : AssemblyBuilderAccess.RunAndSave,
                     dumpDir
                 );
 
                 ab.SetCustomAttribute(new CustomAttributeBuilder(DynamicMethodDefinition.c_UnverifiableCodeAttribute, []));
 
-                if (dmd.Debug) {
+                if (dmd.Debug)
+                {
                     ab.SetCustomAttribute(new CustomAttributeBuilder(DynamicMethodDefinition.c_DebuggableAttribute, [
                         DebuggableAttribute.DebuggingModes.DisableOptimizations | DebuggableAttribute.DebuggingModes.Default
                     ]));
@@ -74,10 +85,12 @@ namespace MonoMod.Utils {
             Type[][] argTypesModReq;
             Type[][] argTypesModOpt;
 
-            if (orig != null) {
+            if (orig != null)
+            {
                 var args = orig.GetParameters();
                 var offs = 0;
-                if (!orig.IsStatic) {
+                if (!orig.IsStatic)
+                {
                     offs++;
                     argTypes = new Type[args.Length + 1];
                     argTypesModReq = new Type[args.Length + 1][];
@@ -85,21 +98,27 @@ namespace MonoMod.Utils {
                     argTypes[0] = orig.GetThisParamType();
                     argTypesModReq[0] = Type.EmptyTypes;
                     argTypesModOpt[0] = Type.EmptyTypes;
-                } else {
+                }
+                else
+                {
                     argTypes = new Type[args.Length];
                     argTypesModReq = new Type[args.Length][];
                     argTypesModOpt = new Type[args.Length][];
                 }
 
-                for (var i = 0; i < args.Length; i++) {
+                for (var i = 0; i < args.Length; i++)
+                {
                     argTypes[i + offs] = args[i].ParameterType;
                     argTypesModReq[i + offs] = args[i].GetRequiredCustomModifiers();
                     argTypesModOpt[i + offs] = args[i].GetOptionalCustomModifiers();
                 }
 
-            } else {
+            }
+            else
+            {
                 var offs = 0;
-                if (def.HasThis) {
+                if (def.HasThis)
+                {
                     offs++;
                     argTypes = new Type[def.Parameters.Count + 1];
                     argTypesModReq = new Type[def.Parameters.Count + 1][];
@@ -110,7 +129,9 @@ namespace MonoMod.Utils {
                     argTypes[0] = type;
                     argTypesModReq[0] = Type.EmptyTypes;
                     argTypesModOpt[0] = Type.EmptyTypes;
-                } else {
+                }
+                else
+                {
                     argTypes = new Type[def.Parameters.Count];
                     argTypesModReq = new Type[def.Parameters.Count][];
                     argTypesModOpt = new Type[def.Parameters.Count][];
@@ -119,7 +140,8 @@ namespace MonoMod.Utils {
                 var modReq = new List<Type>();
                 var modOpt = new List<Type>();
 
-                for (var i = 0; i < def.Parameters.Count; i++) {
+                for (var i = 0; i < def.Parameters.Count; i++)
+                {
                     _DMDEmit.ResolveWithModifiers(def.Parameters[i].ParameterType, out var paramType, out var paramTypeModReq, out var paramTypeModOpt, modReq, modOpt);
                     argTypes[i + offs] = paramType;
                     argTypesModReq[i + offs] = paramTypeModReq;

--- a/src/MonoMod.Utils/DMDGenerators/DMDEmitMethodBuilderGenerator.cs
+++ b/src/MonoMod.Utils/DMDGenerators/DMDEmitMethodBuilderGenerator.cs
@@ -1,4 +1,4 @@
-﻿#if METHODBUILDER_SUPPORTED
+﻿#if NETFRAMEWORK || NET9_0_OR_GREATER
 using MonoMod.Logs;
 using System;
 using System.Collections.Generic;

--- a/src/MonoMod.Utils/DynamicMethodDefinition.cs
+++ b/src/MonoMod.Utils/DynamicMethodDefinition.cs
@@ -1,4 +1,7 @@
-﻿using Mono.Cecil;
+﻿#if NETFRAMEWORK || NET9_0_OR_GREATER
+#define METHODBUILDER_SUPPORTED
+#endif
+using Mono.Cecil;
 using Mono.Cecil.Cil;
 using System;
 using System.Collections.Concurrent;

--- a/src/MonoMod.Utils/DynamicMethodDefinition.cs
+++ b/src/MonoMod.Utils/DynamicMethodDefinition.cs
@@ -222,7 +222,7 @@ namespace MonoMod.Utils
                 {
                     return DMDCecilGenerator.Generate(this, context);
                 }
-#if NETFRAMEWORK
+#if METHODBUILDER_SUPPORTED
                 if (dmdType.Equals("methodbuilder", StringComparison.OrdinalIgnoreCase)
                     || dmdType.Equals("mb", StringComparison.OrdinalIgnoreCase)) {
                     return DMDEmitMethodBuilderGenerator.Generate(this, context);
@@ -246,7 +246,7 @@ namespace MonoMod.Utils
                 return DMDCecilGenerator.Generate(this, context);
 
             if (Debug)
-#if !NETFRAMEWORK
+#if !METHODBUILDER_SUPPORTED
                 return DMDCecilGenerator.Generate(this, context);
 #else
                 return DMDEmitMethodBuilderGenerator.Generate(this, context);

--- a/tools/Common.CS.targets
+++ b/tools/Common.CS.targets
@@ -104,6 +104,11 @@
         <CecilVersion Condition="'$(CecilVersion)' == ''">$(NewCecilVersion)</CecilVersion>
         <NETShimVersion>4.*</NETShimVersion>
       </PropertyGroup>
+      
+      <!-- MethodBuilder-->
+      <PropertyGroup Condition="$([MSBuild]::VersionGreaterThanOrEquals('$(TargetFrameworkVersion)', '9.0'))">
+        <DefineConstants>METHODBUILDER_SUPPORTED;$(DefineConstants)</DefineConstants>
+      </PropertyGroup>
 
       <ItemGroup>
         <!-- For Core 2.1, we need this to make sure it doesn't include the shim assemblies in the package -->
@@ -130,7 +135,7 @@
       <!-- .NET Framework 4.0+ -->
       <PropertyGroup>
         <DefineConstants>NETFRAMEWORK4;$(DefineConstants)</DefineConstants>
-        <DefineConstants>CECIL0_11;$(DefineConstants)</DefineConstants>
+        <DefineConstants>CECIL0_11;METHODBUILDER_SUPPORTED;$(DefineConstants)</DefineConstants>
         <CecilVersion Condition="'$(CecilVersion)' == ''">$(NewCecilVersion)</CecilVersion>
       </PropertyGroup>
       <ItemGroup>
@@ -142,7 +147,7 @@
       <!-- .NET Framework 3.5 -->
       <PropertyGroup>
         <DefineConstants>NETFRAMEWORK3;$(DefineConstants)</DefineConstants>
-        <DefineConstants>CECIL0_10;$(DefineConstants)</DefineConstants>
+        <DefineConstants>CECIL0_10;METHODBUILDER_SUPPORTED;$(DefineConstants)</DefineConstants>
         <CecilVersion Condition="'$(CecilVersion)' == ''">$(OldCecilVersion)</CecilVersion>
       </PropertyGroup>
       <ItemGroup>

--- a/tools/Common.CS.targets
+++ b/tools/Common.CS.targets
@@ -104,11 +104,6 @@
         <CecilVersion Condition="'$(CecilVersion)' == ''">$(NewCecilVersion)</CecilVersion>
         <NETShimVersion>4.*</NETShimVersion>
       </PropertyGroup>
-      
-      <!-- MethodBuilder-->
-      <PropertyGroup Condition="$([MSBuild]::VersionGreaterThanOrEquals('$(TargetFrameworkVersion)', '9.0'))">
-        <DefineConstants>METHODBUILDER_SUPPORTED;$(DefineConstants)</DefineConstants>
-      </PropertyGroup>
 
       <ItemGroup>
         <!-- For Core 2.1, we need this to make sure it doesn't include the shim assemblies in the package -->
@@ -135,7 +130,7 @@
       <!-- .NET Framework 4.0+ -->
       <PropertyGroup>
         <DefineConstants>NETFRAMEWORK4;$(DefineConstants)</DefineConstants>
-        <DefineConstants>CECIL0_11;METHODBUILDER_SUPPORTED;$(DefineConstants)</DefineConstants>
+        <DefineConstants>CECIL0_11;$(DefineConstants)</DefineConstants>
         <CecilVersion Condition="'$(CecilVersion)' == ''">$(NewCecilVersion)</CecilVersion>
       </PropertyGroup>
       <ItemGroup>
@@ -147,7 +142,7 @@
       <!-- .NET Framework 3.5 -->
       <PropertyGroup>
         <DefineConstants>NETFRAMEWORK3;$(DefineConstants)</DefineConstants>
-        <DefineConstants>CECIL0_10;METHODBUILDER_SUPPORTED;$(DefineConstants)</DefineConstants>
+        <DefineConstants>CECIL0_10;$(DefineConstants)</DefineConstants>
         <CecilVersion Condition="'$(CecilVersion)' == ''">$(OldCecilVersion)</CecilVersion>
       </PropertyGroup>
       <ItemGroup>


### PR DESCRIPTION
With Net9 introducing PersistedAssemblyBuilder as a way to save AssembyBuilders, there is good reason to support it by allowing the 'methodbuilder' DMDType. For my use case, the 'cecil' generator is over 10 times slower, and with many failures, making it not actually usable. While methodbuilder is more stable and interactable.