### PR TITLE
Fix Interface Default Implementaiton Detour

### DIFF
--- a/src/MonoMod.UnitTest/DynamicMethodDefinitionTest.cs
+++ b/src/MonoMod.UnitTest/DynamicMethodDefinitionTest.cs
@@ -285,5 +285,40 @@ namespace MonoMod.UnitTest
             Assert.Equal(newVarDef, genClone.Definition.Body.Instructions[1].Operand);
             Assert.Equal(newVarDef, genClone.Definition.Body.Instructions[2].Operand);
         }
+#if NETSTANDARD2_1 || NETCOREAPP3_0_OR_GREATER || NET5_0_OR_GREATER
+        [Fact]
+        public void TestInterfaceDefault()
+        {
+            IDefaultInterfaceMethodTarget target = new DefaultInterfaceMethodTarget();
+
+            Assert.Equal(11, target.AddTen(1));
+
+            MethodInfo dynamicDetour;
+            using (var dmd = new DynamicMethodDefinition(typeof(DynamicMethodDefinitionTest).GetMethod(nameof(DefaultInterfaceMethod_Detour), BindingFlags.Static | BindingFlags.NonPublic)))
+            {
+                dynamicDetour = dmd.Generate();
+            }
+
+            using (var h = new Hook(typeof(IDefaultInterfaceMethodTarget).GetMethod(nameof(IDefaultInterfaceMethodTarget.AddTen), BindingFlags.Instance | BindingFlags.Public), dynamicDetour))
+            {
+                Assert.Equal(42, target.AddTen(1));
+            }
+
+            Assert.Equal(11, target.AddTen(1));
+        }
+
+        private interface IDefaultInterfaceMethodTarget
+        {
+            int AddTen(int value) => value + 10;
+        }
+        private sealed class DefaultInterfaceMethodTarget : IDefaultInterfaceMethodTarget
+        {
+        }
+
+        private static int DefaultInterfaceMethod_Detour(IDefaultInterfaceMethodTarget self, int value)
+        {
+            return value + 41;
+        }
+#endif
     }
 }

--- a/src/MonoMod.Utils/DMDGenerators/DMDEmitDynamicMethodGenerator.cs
+++ b/src/MonoMod.Utils/DMDGenerators/DMDEmitDynamicMethodGenerator.cs
@@ -69,12 +69,30 @@ namespace MonoMod.Utils
                 MMDbgLog.Trace($"orig: {orig}");
             MMDbgLog.Trace($"mdef: {def.ReturnType?.ToString() ?? "NULL"} {name}({string.Join(",", def.Parameters.Select(arg => arg?.ParameterType?.ToString() ?? "NULL").ToArray())})");
 
-            var dm = new DynamicMethod(
-                name,
-                typeof(void), argTypes,
-                orig?.DeclaringType ?? typeof(DynamicMethodDefinition),
-                true // If any random errors pop up, try setting this to false first.
-            );
+            DynamicMethod dm;
+            
+            // The runtime only allows certain types to own DynamicMethods; e.g. Mono does not allow Interface- and Array types as owner
+            // The only case where this currently causes issues is default implementations for Interface Methods (t.IsInterface is true)
+            // Check on Mono: https://github.com/mono/mono/blob/main/mcs/class/corlib/System.Reflection.Emit/DynamicMethod.cs#L116
+            // Check on CoreCLR: https://github.com/dotnet/runtime/blob/a6590591ef32ab28632d9bc14efaf0044be728df/src/libraries/System.Private.CoreLib/src/System/Reflection/Emit/DynamicMethod.cs#L271
+            if (orig?.DeclaringType?.UnderlyingSystemType is Type t && (t.HasElementType || t.ContainsGenericParameters || t.IsGenericParameter || t.IsInterface))
+            {
+                dm = new DynamicMethod(
+                    name,
+                    typeof(void), argTypes,
+                    t.Module,
+                    true
+                );
+            } 
+            else 
+            {
+                dm = new DynamicMethod(
+                    name,
+                    typeof(void), argTypes,
+                    orig?.DeclaringType ?? typeof(DynamicMethodDefinition),
+                    true // If any random errors pop up, try setting this to false first.
+                );
+            }
 
             // DynamicMethods don't officially "support" certain return types, such as ByRef types.
             _DynamicMethod_returnType.SetValue(dm, retType);


### PR DESCRIPTION
Trying to detour default implementations of interface methods is currently throwing 

The test implemented in fa8d181ed134fd0d9da04830ef5368b6b8791072 should fail on the supported runtimes. The test is gated behind `NETSTANDARD2_1 || NETCOREAPP3_0_OR_GREATER || NET5_0_OR_GREATER` because afaik those are the cases where interface defaults are supported.

The issue is that the runtime does not allow certain types to become the owner of DynamicMethods; see relevant runtime snippets [CoreCLR](https://github.com/dotnet/runtime/blob/a6590591ef32ab28632d9bc14efaf0044be728df/src/libraries/System.Private.CoreLib/src/System/Reflection/Emit/DynamicMethod.cs#L271) [Mono](https://github.com/mono/mono/blob/main/mcs/class/corlib/System.Reflection.Emit/DynamicMethod.cs#L116)  

The fix used here catches the specific cases that would cause the ArgumentException (using the CoreCLR conditions since those seem to be a superset of the Mono conditions) and use the module as the owner instead.  

As far as I could find out; the owner type on the DynamicMethod is not that important (Its only usage as far as I could find is [here](https://github.com/dotnet/runtime/blob/5ed2d9b4ec57e537c54c7a21805a12a4c3174a69/src/coreclr/System.Private.CoreLib/src/System/RuntimeHandles.cs#L2235C37-L2235C50)); so the fix shouldn't cause issues.

The currently only relevant case where this issue triggers is for Interface Defaults; because the owner type is an interface. I can't imagine any of the other conditions causing issues in the future; but it might be preferable to just use them anyway to future-proof?  