### PR TITLE
Add Test for and fix #299

### DIFF
--- a/src/MonoMod.UnitTest/DynamicMethodDefinitionTest.cs
+++ b/src/MonoMod.UnitTest/DynamicMethodDefinitionTest.cs
@@ -1,4 +1,4 @@
-﻿extern alias New;
+extern alias New;
 
 using Mono.Cecil.Cil;
 using MonoMod.Cil;
@@ -324,11 +324,11 @@ namespace MonoMod.UnitTest
                 var methodBuilder = DMDEmitMethodBuilderGenerator.GenerateMethodBuilder(dmd, typeBuilder);
                 Assert.NotNull(methodBuilder);
                 var methodBuilder2 = DMDEmitMethodBuilderGenerator.GenerateMethodBuilder(dmd2, typeBuilder);
-                Assert.NotNull(methodBuilder);
+                Assert.NotNull(methodBuilder2);
                 var methodBuilder3 = DMDEmitMethodBuilderGenerator.GenerateMethodBuilder(dmd3, typeBuilder);
-                Assert.NotNull(methodBuilder);
+                Assert.NotNull(methodBuilder3);
                 var methodBuilder4 = DMDEmitMethodBuilderGenerator.GenerateMethodBuilder(dmd3, typeBuilder);
-                Assert.NotNull(methodBuilder);
+                Assert.NotNull(methodBuilder4);
 
                 var generatedType = typeBuilder.CreateType();
                 Assert.NotNull(generatedType);

--- a/src/MonoMod.UnitTest/DynamicMethodDefinitionTest.cs
+++ b/src/MonoMod.UnitTest/DynamicMethodDefinitionTest.cs
@@ -285,6 +285,67 @@ namespace MonoMod.UnitTest
             Assert.Equal(newVarDef, genClone.Definition.Body.Instructions[1].Operand);
             Assert.Equal(newVarDef, genClone.Definition.Body.Instructions[2].Operand);
         }
+#if NETFRAMEWORK
+        // https://github.com/MonoMod/MonoMod/issues/299
+        [Fact]
+        public void TestSaveDMDEmitMethodBuilderGenerator()
+        {
+            Console.WriteLine("TestSaveDMDEmitMethodBuilderGenerator Started");
+            var assemblyName = new AssemblyName($"MonoMod.UnitTest.DMDSave_{Guid.NewGuid():N}");
+            var assemblyFileName = $"{assemblyName.Name}.dll";
+
+            if (System.IO.File.Exists(assemblyFileName))
+            {
+                System.IO.File.Delete(assemblyFileName);
+            }
+
+            try
+            {
+                var assemblyBuilder = AppDomain.CurrentDomain.DefineDynamicAssembly(assemblyName, AssemblyBuilderAccess.RunAndSave);
+                var dynamicModule = assemblyBuilder.DefineDynamicModule(assemblyName.Name, assemblyFileName);
+                var typeBuilder = dynamicModule.DefineType("TestType", TypeAttributes.Public);
+
+                using var dmd = new DynamicMethodDefinition("Test", typeof(void), []);
+                var il = dmd.GetILGenerator();
+                il.Emit(System.Reflection.Emit.OpCodes.Ret);
+
+                using var dmd2 = new DynamicMethodDefinition("Test2", typeof(void), [typeof(int)]);
+                var il2 = dmd2.GetILGenerator();
+                il2.Emit(System.Reflection.Emit.OpCodes.Ret);
+
+                using var dmd3 = new DynamicMethodDefinition("Test3", typeof(int), []);
+                var il3 = dmd3.GetILGenerator();
+                il3.Emit(System.Reflection.Emit.OpCodes.Ret);
+
+                using var dmd4 = new DynamicMethodDefinition("Test4", typeof(int), [typeof(int)]);
+                var il4 = dmd4.GetILGenerator();
+                il4.Emit(System.Reflection.Emit.OpCodes.Ret);
+
+                var methodBuilder = DMDEmitMethodBuilderGenerator.GenerateMethodBuilder(dmd, typeBuilder);
+                Assert.NotNull(methodBuilder);
+                var methodBuilder2 = DMDEmitMethodBuilderGenerator.GenerateMethodBuilder(dmd2, typeBuilder);
+                Assert.NotNull(methodBuilder);
+                var methodBuilder3 = DMDEmitMethodBuilderGenerator.GenerateMethodBuilder(dmd3, typeBuilder);
+                Assert.NotNull(methodBuilder);
+                var methodBuilder4 = DMDEmitMethodBuilderGenerator.GenerateMethodBuilder(dmd3, typeBuilder);
+                Assert.NotNull(methodBuilder);
+
+                var generatedType = typeBuilder.CreateType();
+                Assert.NotNull(generatedType);
+
+                assemblyBuilder.Save(assemblyFileName);
+                Assert.True(System.IO.File.Exists(assemblyFileName));
+            }
+            finally
+            {
+                if (System.IO.File.Exists(assemblyFileName))
+                {
+                    System.IO.File.Delete(assemblyFileName);
+                }
+            }
+            Console.WriteLine("TestSaveDMDEmitMethodBuilderGenerator Finished");
+        }
+#endif
 #if NETSTANDARD2_1 || NETCOREAPP3_0_OR_GREATER || NET5_0_OR_GREATER
         [Fact]
         public void TestInterfaceDefault()

--- a/src/MonoMod.Utils/DMDGenerators/DMDEmitMethodBuilderGenerator.cs
+++ b/src/MonoMod.Utils/DMDGenerators/DMDEmitMethodBuilderGenerator.cs
@@ -194,6 +194,19 @@ namespace MonoMod.Utils
             // Required because the return type modifiers aren't easily accessible via reflection.
             _DMDEmit.ResolveWithModifiers(def.ReturnType, out var returnType, out var returnTypeModReq, out var returnTypeModOpt);
 
+
+#if NETFRAMEWORK
+            // https://github.com/MonoMod/MonoMod/issues/299
+            // https://github.com/mono/mono/blob/0f53e9e151d92944cacab3e24ac359410c606df6/mono/metadata/sre-encode.c#L290
+            if (PlatformDetection.Runtime == RuntimeKind.Mono)
+            {
+                SanitizeForMono(ref returnTypeModReq);
+                SanitizeForMono(ref returnTypeModOpt);
+                SanitizeForMono(ref argTypesModReq);
+                SanitizeForMono(ref argTypesModOpt);
+            }
+#endif
+
             var mb = typeBuilder.DefineMethod(
                 dmd.Name ?? (orig?.Name ?? def.Name).Replace('.', '_'),
                 System.Reflection.MethodAttributes.HideBySig | System.Reflection.MethodAttributes.Public | System.Reflection.MethodAttributes.Static,
@@ -207,7 +220,32 @@ namespace MonoMod.Utils
 
             return mb;
         }
-
+#if NETFRAMEWORK
+        private static void SanitizeForMono(ref Type[] toSanitize)
+        {
+            if (toSanitize.Length == 0)
+            {
+                toSanitize = null!;
+            }
+        }
+        private static void SanitizeForMono(ref Type[][] toSanitize)
+        {
+            if (toSanitize.Length == 0)
+            {
+                toSanitize = null!;
+            } 
+            else
+            {
+                for (var i = 0; i < toSanitize.Length; i++)
+                {
+                    if (toSanitize[i].Length == 0)
+                    {
+                        toSanitize[i] = null!;
+                    }
+                }
+            }
+        }
+#endif
     }
 }
 #endif


### PR DESCRIPTION
Screenshot of the test actually failing on a mono runtime:
<img width="958" height="210" alt="grafik" src="https://github.com/user-attachments/assets/dcf01260-5d4f-4b7a-ae2e-dd74353d6c49" />
Screenshot of it passing on the same runtime after the fix:
<img width="776" height="129" alt="grafik" src="https://github.com/user-attachments/assets/f652f130-c6ca-46fd-96ed-6d1e5d59229d" />

Relevant mono snippet: https://github.com/mono/mono/blob/0f53e9e151d92944cacab3e24ac359410c606df6/mono/metadata/sre-encode.c#L290

Fixes #299 