### PR TITLE
Fix #282

### DIFF
--- a/src/MonoMod.UnitTest/Github/Issue282.cs
+++ b/src/MonoMod.UnitTest/Github/Issue282.cs
@@ -1,0 +1,54 @@
+using MonoMod.Cil;
+using MonoMod.Utils;
+using MonoMod;
+using Mono.Cecil.Cil;
+using System;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace MonoMod.UnitTest.Github
+{
+    public class Issue282 : TestBase
+    {
+        public Issue282(ITestOutputHelper helper) : base(helper)
+        {
+        }
+
+        [Fact]
+        public void DMDGenerateDoesNotOverrideParameters()
+        {
+            using var dmd = new DynamicMethodDefinition(((Delegate)func).Method);
+            // modify to func(a, b) => a + b;
+            dmd.Definition.Parameters.Add(new(dmd.Module.TypeSystem.Int32));
+            using (var il = new ILContext(dmd.Definition))
+            {
+                var c = new ILCursor(il);
+                c.Index += 1;
+                c.Emit(OpCodes.Ldarg_1);
+                c.Emit(OpCodes.Add);
+            }
+
+            Assert.Equal(1, func(1));
+            Test("cecil");
+            Test("dynamicmethod");
+#if NETFRAMEWORK
+            Test("methodbuilder");
+#endif
+
+            static int func(int a) => a;
+            void Test(string dmdtype)
+            {
+                try
+                {
+                    Switches.SetSwitchValue(Switches.DMDType, dmdtype);
+                    var newfunc = dmd.Generate().CreateDelegate<Func<int, int, int>>();
+                    Assert.Equal(3, newfunc(1, 2));
+                }
+                finally
+                {
+                    Switches.ClearSwitchValue(Switches.DMDType);
+                }
+            }
+        }
+    }
+}

--- a/src/MonoMod.UnitTest/Github/Issue282.cs
+++ b/src/MonoMod.UnitTest/Github/Issue282.cs
@@ -1,13 +1,14 @@
+using Mono.Cecil.Cil;
 using MonoMod.Cil;
 using MonoMod.Utils;
-using MonoMod;
-using Mono.Cecil.Cil;
 using System;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace MonoMod.UnitTest.Github
 {
+    [CollectionDefinition(nameof(Issue282), DisableParallelization = true)]
+    [Collection(nameof(Issue282))]
     public class Issue282 : TestBase
     {
         public Issue282(ITestOutputHelper helper) : base(helper)

--- a/src/MonoMod.Utils/DMDGenerators/DMDEmitDynamicMethodGenerator.cs
+++ b/src/MonoMod.Utils/DMDGenerators/DMDEmitDynamicMethodGenerator.cs
@@ -44,21 +44,21 @@ namespace MonoMod.Utils
             else
             {*/
             var offs = 0;
-                if (def.HasThis)
-                {
-                    offs++;
-                    argTypes = new Type[def.Parameters.Count + 1];
-                    var type = def.DeclaringType.ResolveReflection();
-                    if (type.IsValueType)
-                        type = type.MakeByRefType();
-                    argTypes[0] = type;
-                }
-                else
-                {
-                    argTypes = new Type[def.Parameters.Count];
-                }
-                for (var i = 0; i < def.Parameters.Count; i++)
-                    argTypes[i + offs] = def.Parameters[i].ParameterType.ResolveReflection();
+            if (def.HasThis)
+            {
+                offs++;
+                argTypes = new Type[def.Parameters.Count + 1];
+                var type = def.DeclaringType.ResolveReflection();
+                if (type.IsValueType)
+                    type = type.MakeByRefType();
+                argTypes[0] = type;
+            }
+            else
+            {
+                argTypes = new Type[def.Parameters.Count];
+            }
+            for (var i = 0; i < def.Parameters.Count; i++)
+                argTypes[i + offs] = def.Parameters[i].ParameterType.ResolveReflection();
             //}
 
             // we do the (object?) dance using DebugFormatter to avoid internal StringBuilders in the ToString (and GetID) implementations which may cause problems
@@ -71,7 +71,7 @@ namespace MonoMod.Utils
             MMDbgLog.Trace($"mdef: {def.ReturnType?.ToString() ?? "NULL"} {name}({string.Join(",", def.Parameters.Select(arg => arg?.ParameterType?.ToString() ?? "NULL").ToArray())})");
 
             DynamicMethod dm;
-            
+
             // The runtime only allows certain types to own DynamicMethods; e.g. Mono does not allow Interface- and Array types as owner
             // The only case where this currently causes issues is default implementations for Interface Methods (t.IsInterface is true)
             // Check on Mono: https://github.com/mono/mono/blob/main/mcs/class/corlib/System.Reflection.Emit/DynamicMethod.cs#L116
@@ -84,8 +84,8 @@ namespace MonoMod.Utils
                     t.Module,
                     true
                 );
-            } 
-            else 
+            }
+            else
             {
                 dm = new DynamicMethod(
                     name,

--- a/src/MonoMod.Utils/DMDGenerators/DMDEmitDynamicMethodGenerator.cs
+++ b/src/MonoMod.Utils/DMDGenerators/DMDEmitDynamicMethodGenerator.cs
@@ -22,6 +22,7 @@ namespace MonoMod.Utils
 
             Type[] argTypes;
 
+            /* In case of differing parameters, this branch causes https://github.com/MonoMod/MonoMod/issues/282
             if (orig != null)
             {
                 var args = orig.GetParameters();
@@ -41,8 +42,8 @@ namespace MonoMod.Utils
 
             }
             else
-            {
-                var offs = 0;
+            {*/
+            var offs = 0;
                 if (def.HasThis)
                 {
                     offs++;
@@ -58,7 +59,7 @@ namespace MonoMod.Utils
                 }
                 for (var i = 0; i < def.Parameters.Count; i++)
                     argTypes[i + offs] = def.Parameters[i].ParameterType.ResolveReflection();
-            }
+            //}
 
             // we do the (object?) dance using DebugFormatter to avoid internal StringBuilders in the ToString (and GetID) implementations which may cause problems
             var name = dmd.Name ?? DebugFormatter.Format($"DMD<{(object?)orig ?? def.GetID(simple: true)}>");

--- a/src/MonoMod.Utils/DMDGenerators/DMDEmitMethodBuilderGenerator.cs
+++ b/src/MonoMod.Utils/DMDGenerators/DMDEmitMethodBuilderGenerator.cs
@@ -127,6 +127,7 @@ namespace MonoMod.Utils
             Type[][] argTypesModReq;
             Type[][] argTypesModOpt;
 
+            /* In case of differing parameters, this branch causes https://github.com/MonoMod/MonoMod/issues/282
             if (orig != null)
             {
                 var args = orig.GetParameters();
@@ -157,8 +158,8 @@ namespace MonoMod.Utils
 
             }
             else
-            {
-                var offs = 0;
+            {*/
+            var offs = 0;
                 if (def.HasThis)
                 {
                     offs++;
@@ -189,7 +190,7 @@ namespace MonoMod.Utils
                     argTypesModReq[i + offs] = paramTypeModReq;
                     argTypesModOpt[i + offs] = paramTypeModOpt;
                 }
-            }
+            //}
 
             // Required because the return type modifiers aren't easily accessible via reflection.
             _DMDEmit.ResolveWithModifiers(def.ReturnType, out var returnType, out var returnTypeModReq, out var returnTypeModOpt);

--- a/src/MonoMod.Utils/DMDGenerators/DMDEmitMethodBuilderGenerator.cs
+++ b/src/MonoMod.Utils/DMDGenerators/DMDEmitMethodBuilderGenerator.cs
@@ -160,36 +160,36 @@ namespace MonoMod.Utils
             else
             {*/
             var offs = 0;
-                if (def.HasThis)
-                {
-                    offs++;
-                    argTypes = new Type[def.Parameters.Count + 1];
-                    argTypesModReq = new Type[def.Parameters.Count + 1][];
-                    argTypesModOpt = new Type[def.Parameters.Count + 1][];
-                    var type = def.DeclaringType.ResolveReflection();
-                    if (type.IsValueType)
-                        type = type.MakeByRefType();
-                    argTypes[0] = type;
-                    argTypesModReq[0] = Type.EmptyTypes;
-                    argTypesModOpt[0] = Type.EmptyTypes;
-                }
-                else
-                {
-                    argTypes = new Type[def.Parameters.Count];
-                    argTypesModReq = new Type[def.Parameters.Count][];
-                    argTypesModOpt = new Type[def.Parameters.Count][];
-                }
+            if (def.HasThis)
+            {
+                offs++;
+                argTypes = new Type[def.Parameters.Count + 1];
+                argTypesModReq = new Type[def.Parameters.Count + 1][];
+                argTypesModOpt = new Type[def.Parameters.Count + 1][];
+                var type = def.DeclaringType.ResolveReflection();
+                if (type.IsValueType)
+                    type = type.MakeByRefType();
+                argTypes[0] = type;
+                argTypesModReq[0] = Type.EmptyTypes;
+                argTypesModOpt[0] = Type.EmptyTypes;
+            }
+            else
+            {
+                argTypes = new Type[def.Parameters.Count];
+                argTypesModReq = new Type[def.Parameters.Count][];
+                argTypesModOpt = new Type[def.Parameters.Count][];
+            }
 
-                var modReq = new List<Type>();
-                var modOpt = new List<Type>();
+            var modReq = new List<Type>();
+            var modOpt = new List<Type>();
 
-                for (var i = 0; i < def.Parameters.Count; i++)
-                {
-                    _DMDEmit.ResolveWithModifiers(def.Parameters[i].ParameterType, out var paramType, out var paramTypeModReq, out var paramTypeModOpt, modReq, modOpt);
-                    argTypes[i + offs] = paramType;
-                    argTypesModReq[i + offs] = paramTypeModReq;
-                    argTypesModOpt[i + offs] = paramTypeModOpt;
-                }
+            for (var i = 0; i < def.Parameters.Count; i++)
+            {
+                _DMDEmit.ResolveWithModifiers(def.Parameters[i].ParameterType, out var paramType, out var paramTypeModReq, out var paramTypeModOpt, modReq, modOpt);
+                argTypes[i + offs] = paramType;
+                argTypesModReq[i + offs] = paramTypeModReq;
+                argTypesModOpt[i + offs] = paramTypeModOpt;
+            }
             //}
 
             // Required because the return type modifiers aren't easily accessible via reflection.


### PR DESCRIPTION
This adds the test from #289 and forces it to run sequentially (as otherwise it will cause other tests to fail, probably because SetSwitchValue)

Further it removes (comments out) the branches responsible for copying the parameters from the original in both the MethodBuilder and the DynamicMethod generators. I'm not sure if this should be left as is. It does fix the test (and doesn't break any of the old ones). I assume this branch existed for performance reasons? As far as I can see, the Cecil generator already ignores the original method for the sake of parameters.

Note: I suggest hiding whitespace when looking at the diff