### PR TITLE
Add a MatchBranch IL pattern matching extension method

### DIFF
--- a/src/MonoMod.Utils/Cil/ILPatternMatchingExt.cs
+++ b/src/MonoMod.Utils/Cil/ILPatternMatchingExt.cs
@@ -15,6 +15,36 @@ namespace MonoMod.Cil
     [EmitILOverloads("ILOpcodes.txt", ILOverloadKind.Matcher)]
     public static partial class ILPatternMatchingExt
     {
+        private static readonly HashSet<OpCode> BranchOpCodes =
+        [
+            OpCodes.Br_S,
+            OpCodes.Brfalse_S,
+            OpCodes.Brtrue_S,
+            OpCodes.Beq_S,
+            OpCodes.Bge_S,
+            OpCodes.Bgt_S,
+            OpCodes.Ble_S,
+            OpCodes.Blt_S,
+            OpCodes.Bne_Un_S,
+            OpCodes.Bge_Un_S,
+            OpCodes.Bgt_Un_S,
+            OpCodes.Ble_Un_S,
+            OpCodes.Blt_Un_S,
+            OpCodes.Br,
+            OpCodes.Brfalse,
+            OpCodes.Brtrue,
+            OpCodes.Beq,
+            OpCodes.Bge,
+            OpCodes.Bgt,
+            OpCodes.Ble,
+            OpCodes.Blt,
+            OpCodes.Bne_Un,
+            OpCodes.Bge_Un,
+            OpCodes.Bgt_Un,
+            OpCodes.Ble_Un,
+            OpCodes.Blt_Un
+        ];
+
         #region Equivalence definitions
         private static bool IsEquivalent(int l, int r) => l == r;
         private static bool IsEquivalent(int l, uint r) => unchecked((uint)l) == r;
@@ -461,6 +491,42 @@ namespace MonoMod.Cil
             if ((instr.OpCode == OpCodes.Call || instr.OpCode == OpCodes.Callvirt) && instr.Operand is MethodReference mr)
             {
                 value = mr;
+                return true;
+            }
+            else
+            {
+                value = default;
+                return false;
+            }
+        }
+
+        /// <summary>Matches a branch instruction.</summary>
+        /// <param name="instr">The instruction to try to match.</param>
+        /// <param name="value">The operand value required for the instruction to match.</param>
+        /// <returns><see langword="true"/> if the instruction matches; <see langword="false"/> otherwise.</returns>
+        /// <remarks>This will match an instruction whose opcode is <see cref="OpCodes.Br"/>, <see cref="OpCodes.Brfalse"/>, <see cref="OpCodes.Brtrue"/>, <see cref="OpCodes.Beq"/>, <see cref="OpCodes.Bge"/>, <see cref="OpCodes.Bgt"/>, <see cref="OpCodes.Ble"/>, <see cref="OpCodes.Blt"/>, <see cref="OpCodes.Bne_Un"/>, <see cref="OpCodes.Bge_Un"/>, <see cref="OpCodes.Bgt_Un"/>, <see cref="OpCodes.Ble_Un"/> or <see cref="OpCodes.Blt_Un"/>.</remarks>
+        public static bool MatchBranch(this Instruction instr, ILLabel value)
+            => MatchBranch(instr, out var v) && IsEquivalent(v, value);
+
+        /// <summary>Matches a branch instruction.</summary>
+        /// <param name="instr">The instruction to try to match.</param>
+        /// <param name="value">The operand value required for the instruction to match.</param>
+        /// <returns><see langword="true"/> if the instruction matches; <see langword="false"/> otherwise.</returns>
+        /// <remarks>This will match an instruction whose opcode is <see cref="OpCodes.Br"/>, <see cref="OpCodes.Brfalse"/>, <see cref="OpCodes.Brtrue"/>, <see cref="OpCodes.Beq"/>, <see cref="OpCodes.Bge"/>, <see cref="OpCodes.Bgt"/>, <see cref="OpCodes.Ble"/>, <see cref="OpCodes.Blt"/>, <see cref="OpCodes.Bne_Un"/>, <see cref="OpCodes.Bge_Un"/>, <see cref="OpCodes.Bgt_Un"/>, <see cref="OpCodes.Ble_Un"/> or <see cref="OpCodes.Blt_Un"/>.</remarks>
+        public static bool MatchBranch(this Instruction instr, Instruction value)
+            => MatchBranch(instr, out var v) && IsEquivalent(v, value);
+
+        /// <summary>Matches a branch instruction.</summary>
+        /// <param name="instr">The instruction to try to match.</param>
+        /// <param name="value">The operand value of the instruction.</param>
+        /// <returns><see langword="true"/> if the instruction matches; <see langword="false"/> otherwise.</returns>
+        /// <remarks>This will match an instruction whose opcode is <see cref="OpCodes.Br"/>, <see cref="OpCodes.Brfalse"/>, <see cref="OpCodes.Brtrue"/>, <see cref="OpCodes.Beq"/>, <see cref="OpCodes.Bge"/>, <see cref="OpCodes.Bgt"/>, <see cref="OpCodes.Ble"/>, <see cref="OpCodes.Blt"/>, <see cref="OpCodes.Bne_Un"/>, <see cref="OpCodes.Bge_Un"/>, <see cref="OpCodes.Bgt_Un"/>, <see cref="OpCodes.Ble_Un"/> or <see cref="OpCodes.Blt_Un"/>.</remarks>
+        public static bool MatchBranch(this Instruction instr, [MaybeNullWhen(false)] out ILLabel value)
+        {
+            Helpers.ThrowIfArgumentNull(instr);
+            if (BranchOpCodes.Contains(instr.OpCode) && instr.Operand is ILLabel label)
+            {
+                value = label;
                 return true;
             }
             else


### PR DESCRIPTION
This adds an extension methods (and fitting overloads) to match an instructions among the set of branching instructions opcodes. This is aimed to replicate a feature that wasn't present in MonoMod, but was in Harmony (its implementation can be found here: https://github.com/pardeike/Harmony/blob/e9e9554d1f79f310d98ddeea2bd7dc7970a5a046/Harmony/Tools/Extensions.cs#L482-L496 ).

The main use of this is to navigate the control flow in the IL in such a way that the caller would be interested to see a branch, but doesn't necessarily care how it's done. For example, a brtrue is really the same than a brfalse with the operand being inverted. If some kind of changes were to happen to the original and causes the IL to change to be semantically similar, but syntactically different in the IL, a match for the specific opcode would no longer work while this new extension method could still function.

It of course doesn't guarantee it, but it definitely helps and I have encountered such situations before. Additionally, it in my opinion improves the expressiveness of patern matching because it makes it more clear that the caller is interested in the kinds of control flow of the IL rather than a specific branching instruction.