### PR TITLE
Fix detour target being wrong under certain circumstances

### DIFF
--- a/src/MonoMod.Core/Platforms/Memory/QueryingPagedMemoryAllocator.cs
+++ b/src/MonoMod.Core/Platforms/Memory/QueryingPagedMemoryAllocator.cs
@@ -148,6 +148,14 @@ namespace MonoMod.Core.Platforms.Memory
                     goto Fail;
                 }
 
+                if ((nint)alloc.BaseAddress < request.LowBound || (nint)alloc.BaseAddress >= request.HighBound)
+                {
+                    MMDbgLog.Error($"Got allocation request at {request.Target:X} within range [{request.LowBound:X}, {request.HighBound:X}) but received out-of-bounds allocation {alloc.BaseAddress:X} within page {pageObj.BaseAddr:X} (size: {pageObj.Size}). TryQueryPage gave baseAddr: {baseAddr:X}");
+                    alloc.Dispose();
+                    RegisterForCleanup(pageObj);
+                    goto Fail;
+                }
+
                 // we successfully allocated, return the page allocation
                 allocated = alloc;
                 return true;

--- a/src/MonoMod.Core/Platforms/Systems/WindowsSystem.cs
+++ b/src/MonoMod.Core/Platforms/Systems/WindowsSystem.cs
@@ -265,11 +265,18 @@ namespace MonoMod.Core.Platforms.Systems
         private sealed class PageAllocator : QueryingMemoryPageAllocatorBase
         {
             public override uint PageSize { get; }
+            public nuint MinimumApplicationAddress { get; }
+            public nuint MaximumApplicationAddress { get; }
 
             public PageAllocator()
             {
                 SYSTEM_INFO sysInfo;
-                unsafe { GetSystemInfo(&sysInfo); }
+                unsafe
+                {
+                    GetSystemInfo(&sysInfo);
+                    MinimumApplicationAddress = (nuint)sysInfo.lpMinimumApplicationAddress;
+                    MaximumApplicationAddress = (nuint)sysInfo.lpMaximumApplicationAddress;
+                }
                 PageSize = sysInfo.dwAllocationGranularity; // we use the allocation granularity instead of actual page size so we don't create tons of unusable holes in the address space
             }
 
@@ -308,7 +315,8 @@ namespace MonoMod.Core.Platforms.Systems
                 // Windows contractually guarantees that the zero page is permanently unallocated,
                 // and passing a null pointer to VirtualAlloc will allocate at an arbitrary point in memory
                 // causing allocation at possibly unintended locations, see https://github.com/MonoMod/MonoMod/pull/308
-                var isValidAddress = pageAddr != IntPtr.Zero;
+                var addrVal = (nuint)(nint)pageAddr;
+                var isValidAddress = addrVal >= MinimumApplicationAddress && addrVal <= MaximumApplicationAddress;
                 if (isValidAddress && Interop.Windows.VirtualQuery((void*)pageAddr, &buffer, (nuint)sizeof(MEMORY_BASIC_INFORMATION)) != 0)
                 {
                     isFree = buffer.State == MEM_FREE;

--- a/src/MonoMod.Core/Platforms/Systems/WindowsSystem.cs
+++ b/src/MonoMod.Core/Platforms/Systems/WindowsSystem.cs
@@ -305,7 +305,11 @@ namespace MonoMod.Core.Platforms.Systems
             public unsafe override bool TryQueryPage(IntPtr pageAddr, out bool isFree, out IntPtr allocBase, out nint allocSize)
             {
                 MEMORY_BASIC_INFORMATION buffer;
-                if (Interop.Windows.VirtualQuery((void*)pageAddr, &buffer, (nuint)sizeof(MEMORY_BASIC_INFORMATION)) != 0)
+                // Windows contractually guarantees that the zero page is permanently unallocated,
+                // and passing a null pointer to VirtualAlloc will allocate at an arbitrary point in memory
+                // causing allocation at possibly unintended locations, see https://github.com/MonoMod/MonoMod/pull/308
+                var isValidAddress = pageAddr != IntPtr.Zero;
+                if (isValidAddress && Interop.Windows.VirtualQuery((void*)pageAddr, &buffer, (nuint)sizeof(MEMORY_BASIC_INFORMATION)) != 0)
                 {
                     isFree = buffer.State == MEM_FREE;
                     allocBase = isFree ? (nint)buffer.BaseAddress : (nint)buffer.AllocationBase;

--- a/src/MonoMod.UnitTest/Github/Issue308.cs
+++ b/src/MonoMod.UnitTest/Github/Issue308.cs
@@ -1,0 +1,30 @@
+﻿using MonoMod.Core.Platforms;
+using System;
+using Xunit;
+
+namespace MonoMod.UnitTest.Github
+{
+    [CollectionDefinition(nameof(Issue308), DisableParallelization = true)]
+    [Collection(nameof(Issue308))]
+    public class Issue308
+    {
+        [Fact]
+        public void TryAllocateInRangeDoesNotReturnOutsideBoundsForZero()
+        {
+            var alloc = PlatformTriple.Current.System.MemoryAllocator;
+            nint pageSize = alloc.MaxSize;
+
+            nint target = 0;
+            nint low = 0;
+            var high = pageSize;
+
+            var req = new PositionedAllocationRequest(target, low, high, new AllocationRequest(IntPtr.Size) { Executable = true });
+            if (alloc.TryAllocateInRange(req, out var allocated))
+            {
+                var addr = (nint)allocated!.BaseAddress;
+                allocated.Dispose();
+                Assert.True(addr >= low && addr < high, $"allocator returned 0x{addr:X}, outside requested bounds [0x{low:X}, 0x{high:X})");
+            }
+        }
+    }
+}


### PR DESCRIPTION
Issue Details:
- The faulty detour is of kind `Rel32Ind64Kind` and created in `x86_64Arch.ComputeDetourInfo`
- The issue is that the offset necessary to reach the allocated cell is larger than the 32 Bit allowed, causing the cast when the operand is emitted to create a different offset to an invalid cell
- The cause of the offset being outside the 32 Bit boundary is that `TryQueryPage` would always return true for the zero page while `VirtualAlloc` will, when passed a null pointer, allocate the cell at an arbitrary location in memory 


Issue Information:
- All incidences I am aware of happened on Unity Mono
- They either happened on Windows with Bottom-Up ASLR disabled or on Linux x86-64 under certain Proton Versions
- The circumstances causing the issue can be volatile, but once it happens, it happens deterministically
- This has been discussed in more detail at https://discord.com/channels/295566538981769216/295570965663055874/1518380798036672683