### PR TITLE
Generic Hooks Sketch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,7 @@ jobs:
     container: ${{ fromJSON(inputs.matrix).container }}
     env:
       LOG_FILE_NAME: testresults.${{ fromJSON(inputs.matrix).os.runner }}.${{ fromJSON(inputs.matrix).dotnet.id != '' && fromJSON(inputs.matrix).dotnet.id || fromJSON(inputs.matrix).dotnet.sdk }}.${{ fromJSON(inputs.matrix).arch }}
+      MONOMOD_LogToFile: ${{ github.workspace }}/monomod-trace.${{ fromJSON(inputs.matrix).dotnet.tfm }}.${{ fromJSON(inputs.matrix).arch }}.log
 
     steps:
     - name: Install coreutils
@@ -184,6 +185,7 @@ jobs:
           TestResults/*.trx
           *.xml
           diaglog.*
+          monomod-trace.*.log
 
     - name: Upload process dumps
       uses: actions/upload-artifact@v6

--- a/src/MonoMod.Core/Interop/Fx.V48.cs
+++ b/src/MonoMod.Core/Interop/Fx.V48.cs
@@ -260,6 +260,15 @@ namespace MonoMod.Core.Interop
                     if (pMD->IsUnboxingStub && pMD->TryAsInstantiated(out var inst))
                         pMD = inst->IMD_GetWrappedMethodDesc();
 
+                    // Instantiating stubs are the per-instantiation thunks emitted for shared generics
+                    // Their own native code is only the context-setup thunk; the shared canonical body lives on the wrapped MethodDesc
+                    if (pMD->IsInstantiatingStub && pMD->TryAsInstantiated(out var istub))
+                        pMD = istub->IMD_GetWrappedMethodDesc();
+
+                    // A non-wrapper instantiated generic method (e.g. Foo<int>) carries its own native code on its own MethodDesc
+                    if (pMD->HasMethodInstantiation && !pMD->IsGenericMethodDefinition && !pMD->IsWrapperStub)
+                        return pMD;
+
                     // this may not actually be necessary for any of the MDs we see, so we'll leave it in its incomplete state
                     // until it actually proves to be an issue
                     if (!pMD->IsTightlyBoundToMethodTable)

--- a/src/MonoMod.Core/MonoMod.Core.csproj
+++ b/src/MonoMod.Core/MonoMod.Core.csproj
@@ -23,4 +23,10 @@
     <PackageReference Include="Mono.Cecil" />
   </ItemGroup>
 
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>MonoMod.RuntimeDetour</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
 </Project>

--- a/src/MonoMod.Core/Platforms/Memory/PagedMemoryAllocator.cs
+++ b/src/MonoMod.Core/Platforms/Memory/PagedMemoryAllocator.cs
@@ -375,7 +375,9 @@ namespace MonoMod.Core.Platforms.Memory
             pageCount++;
         }
 
-        private void RemoveAllocatedPage(Page page)
+        // Returns true only if this exact page object was found in the allocation list and removed;
+        // false if it is absent or a different page now occupies that base address.
+        private bool RemoveAllocatedPage(Page page)
         {
             var list = allocationList.AsSpan();
 
@@ -384,12 +386,18 @@ namespace MonoMod.Core.Platforms.Memory
             if (indexToRemove < 0)
             {
                 // the page doesn't exist, nothing needs to be done
-                return;
+                return false;
+            }
+
+            if (!ReferenceEquals(list[indexToRemove], page))
+            {
+                return false;
             }
 
             // just copy from above the index down
             list.Slice(indexToRemove + 1).CopyTo(list.Slice(indexToRemove));
             pageCount--;
+            return true;
         }
 
         private ReadOnlySpan<Page> AllocList => allocationList.AsSpan().Slice(0, pageCount)!;
@@ -432,6 +440,7 @@ namespace MonoMod.Core.Platforms.Memory
 
             while (pagesToClean.TryTake(out var page))
             {
+                bool removed;
                 lock (sync)
                 {
                     // if the page is no longer empty, don't free
@@ -439,14 +448,20 @@ namespace MonoMod.Core.Platforms.Memory
                         continue;
 
                     // otherwise, remove it from the allocation list, so we can free it outside the lock
-                    RemoveAllocatedPage(page);
+                    removed = RemoveAllocatedPage(page);
+                }
+
+                if (!removed)
+                {
+                    MMDbgLog.Warning($"Skipped freeing stale/duplicate page at 0x{page.BaseAddr:x16} (size 0x{page.Size:x}); would have double-freed");
+                    continue;
                 }
 
                 // now we can actually free the associated memory
                 if (!TryFreePage(page, out var error))
                 {
                     // free failed; log the error and move on
-                    MMDbgLog.Error($"Could not deallocate page! {error}");
+                    MMDbgLog.Error($"Could not deallocate page at 0x{page.BaseAddr:x16} (size 0x{page.Size:x})! {error}");
                 }
             }
 

--- a/src/MonoMod.Core/Platforms/PlatformTriple.cs
+++ b/src/MonoMod.Core/Platforms/PlatformTriple.cs
@@ -490,7 +490,7 @@ namespace MonoMod.Core.Platforms
         {
             if (SupportedFeatures.Has(RuntimeFeature.RequiresBodyThunkWalking))
             {
-                return GetNativeMethodBodyWalk(method, reloadPtr: true);
+                return GetNativeMethodBodyWalk(method, true, out _);
             }
             else
             {
@@ -498,8 +498,24 @@ namespace MonoMod.Core.Platforms
             }
         }
 
-        private unsafe IntPtr GetNativeMethodBodyWalk(MethodBase method, bool reloadPtr)
+        /// <summary>
+        /// Like <see cref="GetNativeMethodBody"/>, but never forces compilation (compiling certain shared generic
+        /// instantiations access-violates on .NET Core). Reports whether the walk reached a real shared generic body
+        /// by following an instantiating stub, as opposed to stopping at a precode-fixup thunk for an uncompiled method.
+        /// </summary>
+        internal IntPtr GetSharedGenericBodyNoReload(MethodBase method, out bool followedInstantiatingStub)
         {
+            if (SupportedFeatures.Has(RuntimeFeature.RequiresBodyThunkWalking))
+            {
+                return GetNativeMethodBodyWalk(method, false, out followedInstantiatingStub);
+            }
+            followedInstantiatingStub = false;
+            return GetNativeMethodBodyDirect(method);
+        }
+
+        private unsafe IntPtr GetNativeMethodBodyWalk(MethodBase method, bool reloadPtr, out bool followedInstantiatingStub)
+        {
+            followedInstantiatingStub = false;
             var regenerated = false;
             var didPrepareLastIter = false;
             var iters = 0;
@@ -540,7 +556,17 @@ namespace MonoMod.Core.Platforms
 
                 // TODO: be more limiting with which patterns can be scanned forward and which cannot
                 if (!archMatchCollection.TryFindMatch(span, out var addr, out var match, out var offset, out _))
+                {
+                    // The normal scan window (capped at MaxMinLength to avoid running into adjacent stubs)
+                    // is too short to reach the forwarding jump of a generic instantiating stub
+                    if (TryFollowGenericInstantiatingStub(method, entry, readableLen, out var stubBody))
+                    {
+                        MMDbgLog.Trace($"Followed generic instantiating stub at 0x{entry:x16} to shared body 0x{stubBody:x16}");
+                        entry = stubBody;
+                        followedInstantiatingStub = true;
+                    }
                     break;
+                }
 
                 var lastEntry = entry;
 
@@ -588,6 +614,112 @@ namespace MonoMod.Core.Platforms
             return Runtime.GetMethodEntryPoint(method);
         }
 
+        // x86_64 generic instantiating-stub tail patterns. Each stub shifts the user arguments, loads the generic
+        // context into some register, then loads the shared body (or a precode cell holding it) into RAX
+        // (movabs rax = 48 B8) and tail-jumps or calls.
+        private BytePatternCollection? lazyGenericInstantiatingStubs;
+        private unsafe BytePatternCollection GenericInstantiatingStubs
+            => Helpers.GetOrInit(ref lazyGenericInstantiatingStubs, &CreateGenericInstantiatingStubs);
+
+        private const int GenericStubScanWindow = 64;        // generous window; the tail sits well within this
+        private const int GenericStubMaxBodyLoadOffset = 40; // the `movabs rax` must be near the start (it's a stub)
+
+        private static BytePatternCollection CreateGenericInstantiatingStubs()
+        {
+            const ushort Ad = BytePattern.SAddressValue;
+            return new BytePatternCollection(
+                // Windows: movabs rax, {CELL}; mov rax, [rax]; jmp rax (body = *cell)
+                new(new(AddressKind.Abs64 | AddressKind.Indirect), mustMatchAtStart: false,
+                        0x48, 0xb8, Ad, Ad, Ad, Ad, Ad, Ad, Ad, Ad,
+                        0x48, 0x8b, 0x00,
+                        0xff, 0xe0),
+                // SysV: movabs rax, {BODY}; pop rbp; rex.w jmp rax (body = imm)
+                new(new(AddressKind.Abs64), mustMatchAtStart: false,
+                        0x48, 0xb8, Ad, Ad, Ad, Ad, Ad, Ad, Ad, Ad,
+                        0x5d,
+                        0x48, 0xff, 0xe0),
+                // Direct, no frame: movabs rax, {BODY}; jmp rax (body = imm)
+                new(new(AddressKind.Abs64), mustMatchAtStart: false,
+                        0x48, 0xb8, Ad, Ad, Ad, Ad, Ad, Ad, Ad, Ad,
+                        0xff, 0xe0),
+                // Direct, rex.w jmp without a frame pop: movabs rax, {BODY}; rex.w jmp rax
+                new(new(AddressKind.Abs64), mustMatchAtStart: false,
+                        0x48, 0xb8, Ad, Ad, Ad, Ad, Ad, Ad, Ad, Ad,
+                        0x48, 0xff, 0xe0),
+                // Framed shuffle stub (by-value struct arg): sets up a frame and CALLs the body instead of
+                // tail-jmping. movabs rax, {BODY}; call rax (body = imm)
+                new(new(AddressKind.Abs64), mustMatchAtStart: false,
+                        0x48, 0xb8, Ad, Ad, Ad, Ad, Ad, Ad, Ad, Ad,
+                        0xff, 0xd0));
+        }
+
+        // Follows a generic instantiating stub to the shared body it tail-jumps to.
+        private unsafe bool TryFollowGenericInstantiatingStub(MethodBase method, nint entry, nint readableLen, out nint body)
+        {
+            body = 0;
+            // The matched tail shapes are CoreCLR's .NET Core 2.1/3.x instantiating stubs.
+            // Elsewhere the walk reaches the real body instead.
+            if (Architecture.Target != ArchitectureKind.x86_64
+                || PlatformDetection.Runtime != RuntimeKind.CoreCLR
+                || !IsSharedGenericInstantiation(method))
+            {
+                return false;
+            }
+
+            var stubs = GenericInstantiatingStubs;
+            var window = (int)Math.Min((long)readableLen, GenericStubScanWindow);
+            if (window < stubs.MinLength)
+            {
+                return false;
+            }
+
+            var span = new ReadOnlySpan<byte>((void*)entry, window);
+            if (!stubs.TryFindMatch(span, out var addr, out var match, out var offset, out _))
+            {
+                return false;
+            }
+            if (offset > GenericStubMaxBodyLoadOffset)
+            {
+                return false;
+            }
+
+            var resolved = match.AddressMeaning.ProcessAddress(entry, offset, addr);
+            if (resolved == 0 || resolved == entry)
+            {
+                return false;
+            }
+            body = resolved;
+            return true;
+        }
+
+        // True if the method is a closed generic instantiation that uses reference-type code sharing
+        // (so its entry on legacy CoreCLR is an instantiating stub).
+        private static bool IsSharedGenericInstantiation(MethodBase method)
+        {
+            var dt = method.DeclaringType;
+            if (dt is { IsGenericType: true } && !dt.ContainsGenericParameters)
+            {
+                foreach (var a in dt.GetGenericArguments())
+                {
+                    if (!a.IsValueType)
+                    {
+                        return true;
+                    }
+                }
+            }
+            if (method.IsGenericMethod && !method.ContainsGenericParameters)
+            {
+                foreach (var a in method.GetGenericArguments())
+                {
+                    if (!a.IsValueType)
+                    {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+
         private IntPtr ThePreStub = IntPtr.Zero;
 
         // TODO: make this something actually runtime-dependent
@@ -596,26 +728,56 @@ namespace MonoMod.Core.Platforms
             if (ThePreStub == IntPtr.Zero)
             {
                 ThePreStub = (IntPtr)(-2);
-
-                // FIXME: Find a better less likely called NGEN'd candidate that points to ThePreStub.
-                // This was "found" by tModLoader.
-                // Can be missing in .NET 5.0 outside of Windows for some reason.
-
-                // Instead of using any specific method on System.Net.Connection, we just check all of them, as (hopefully) most aren't called by this point
-                var pre = typeof(System.Net.HttpWebRequest).Assembly
-                    .GetType("System.Net.Connection")
-                    ?.GetMethods()
-                    .GroupBy(m => GetNativeMethodBodyWalk(m, reloadPtr: false))
-                    .First(g => g.Count() > 1)
-                    .Key ?? (nint)(-1);
-
-                ThePreStub = pre;
+                ThePreStub = DetectThePreStub();
                 MMDbgLog.Trace($"ThePreStub: 0x{ThePreStub:X16}");
             }
 
-            wasPreStub = ptrParsed == ThePreStub /*|| ThePreStub == (IntPtr) (-1)*/;
+            wasPreStub = ptrParsed == ThePreStub;
 
             return wasPreStub ? ptrGot : ptrParsed;
+        }
+
+        // Prefer own probe type, which is guaranteed to exist and be uncompiled on every runtime.
+        // Previous System.Net.Connection heuristic is kept as a fallback (that internal type is absent on some runtimes),
+        private IntPtr DetectThePreStub()
+        {
+            foreach (var methods in EnumeratePreStubCandidates())
+            {
+                if (methods is null || methods.Length < 2)
+                {
+                    continue;
+                }
+
+                var match = methods.GroupBy(m => (nint)GetNativeMethodBodyWalk(m, false, out _))
+                    .Where(g => g.Count() > 1)
+                    .Select(g => (nint?)g.Key)
+                    .FirstOrDefault();
+
+                if (match is { } found)
+                {
+                    return found;
+                }
+            }
+
+            return (nint)(-1);
+        }
+
+        private static IEnumerable<MethodInfo[]?> EnumeratePreStubCandidates()
+        {
+            yield return typeof(PreStubProbe).GetMethods(BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly);
+            yield return typeof(System.Net.HttpWebRequest).Assembly.GetType("System.Net.Connection")?.GetMethods();
+        }
+
+        private static class PreStubProbe
+        {
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            public static int Probe0() => 0;
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            public static int Probe1() => 1;
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            public static int Probe2() => 2;
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            public static int Probe3() => 3;
         }
 
         /// <summary>
@@ -713,66 +875,10 @@ namespace MonoMod.Core.Platforms
             var returnBufferType = hasReturnBuffer ? returnType.MakeByRefType() : returnType;
             var newReturnType = hasReturnBuffer && !Abi.ReturnsReturnBuffer ? typeof(void) : returnBufferType;
 
-            var thisPos = -1;
-            var returnBufferPos = -1;
-            var userArgumentsOffset = -1;
             var parameters = from.GetParameters();
-            var argumentTypes = new List<Type>(parameters.Length + 3);
-            var argumentKinds = Abi.ArgumentOrder.Span;
-            for (var i = 0; i < argumentKinds.Length; i++)
-            {
-                switch (argumentKinds[i])
-                {
-                    case SpecialArgumentKind.ThisPointer when hasThis:
-                        thisPos = argumentTypes.Count;
-                        argumentTypes.Add(from.GetThisParamType());
-                        break;
-
-                    case SpecialArgumentKind.ReturnBuffer when hasReturnBuffer:
-                        returnBufferPos = argumentTypes.Count;
-                        argumentTypes.Add(returnBufferType);
-                        break;
-
-                    case SpecialArgumentKind.GenericContext when requiresGenericContextFixup:
-                        // Currently, we do the bare minimum: we acknowledge that
-                        // the generic context exists. That's all. After that,
-                        // we simply throw it out of the window and rely on
-                        // the generic context (if any) baked into in the callee.
-                        //
-                        // While this does work fine, it introduces funny little
-                        // holes in the type-safety premise of .NET:
-                        //
-                        // // This may return `false`!
-                        // bool Hook<T>(T it)
-                        //     => typeof(T).IsAssignableFrom(it.GetType());
-                        //
-                        // This behavior is caused by the fact that constructed
-                        // generics for reference types are Java'd into a single
-                        // definition at runtime (and rightfully so).
-                        // So, even if you try to detour a specific generic
-                        // implementation using something like
-                        // `to.MakeGenericMethod(typeof(string))`,
-                        // your hook will receive calls for all
-                        // reference type-based implementations out there.
-                        // However, since we do not patch the generic context
-                        // of the provided hook, it remains unchanged,
-                        // causing `typeof(T)` to defy users' expectations.
-                        //
-                        // So, TODO: patch the generic context of the detour target
-                        // and/or introduce a call filter based on the current context.
-
-                        // The generic context is passed as a pointer to a struct that
-                        // contains all the needed (?) information.
-                        // We can treat it as a simple `IntPtr`.
-                        argumentTypes.Add(typeof(nint));
-                        break;
-
-                    case SpecialArgumentKind.UserArguments:
-                        userArgumentsOffset = argumentTypes.Count;
-                        argumentTypes.AddRange(parameters.Select(static p => p.ParameterType));
-                        break;
-                }
-            }
+            var argumentTypes = BuildAbiArgumentLayout(Abi.ArgumentOrder.Span, from, parameters,
+                hasThis, hasReturnBuffer, requiresGenericContextFixup, returnBufferType,
+                out var thisPos, out var returnBufferPos, out _, out var userArgumentsOffset);
 
             Helpers.DAssert(thisPos >= 0 || !hasThis);
             // note: ARM64 (sysv) uses a dedicated register for the return buffer, so we don't record it as an argument
@@ -781,7 +887,7 @@ namespace MonoMod.Core.Platforms
 
             using var dmd = new DynamicMethodDefinition(
                 DebugFormatter.Format($"Glue:AbiFixup<{from},{to}>"),
-                newReturnType, argumentTypes.ToArray()
+                newReturnType, argumentTypes
             );
             // TODO: make DMD apply attributes to the generated DynamicMethod, when possible
             dmd.Definition!.ImplAttributes |= Mono.Cecil.MethodImplAttributes.NoInlining |
@@ -827,6 +933,77 @@ namespace MonoMod.Core.Platforms
                     return true;
             }
             return false;
+        }
+
+        internal static Type[] BuildAbiArgumentLayout(ReadOnlySpan<SpecialArgumentKind> order, MethodBase from, ParameterInfo[] parameters,
+            bool hasThis, bool hasReturnBuffer, bool hasGenericContext, Type returnBufferType,
+            out int thisPos, out int returnBufferPos, out int genericContextPos, out int userArgumentsOffset,
+            Func<Type, Type>? canonicalize = null)
+        {
+            thisPos = -1;
+            returnBufferPos = -1;
+            genericContextPos = -1;
+            userArgumentsOffset = -1;
+
+            var argumentTypes = new List<Type>(parameters.Length + 3);
+            for (var i = 0; i < order.Length; i++)
+            {
+                switch (order[i])
+                {
+                    case SpecialArgumentKind.ThisPointer when hasThis:
+                        thisPos = argumentTypes.Count;
+                        var thisType = from.GetThisParamType();
+                        argumentTypes.Add(canonicalize is null ? thisType : canonicalize(thisType));
+                        break;
+
+                    case SpecialArgumentKind.ReturnBuffer when hasReturnBuffer:
+                        returnBufferPos = argumentTypes.Count;
+                        argumentTypes.Add(returnBufferType);
+                        break;
+
+                    case SpecialArgumentKind.GenericContext when hasGenericContext:
+                        // Currently, we do the bare minimum: we acknowledge that
+                        // the generic context exists. That's all. After that,
+                        // we simply throw it out of the window and rely on
+                        // the generic context (if any) baked into in the callee.
+                        //
+                        // While this does work fine, it introduces funny little
+                        // holes in the type-safety premise of .NET:
+                        //
+                        // // This may return `false`!
+                        // bool Hook<T>(T it)
+                        //     => typeof(T).IsAssignableFrom(it.GetType());
+                        //
+                        // This behavior is caused by the fact that constructed
+                        // generics for reference types are Java'd into a single
+                        // definition at runtime (and rightfully so).
+                        // So, even if you try to detour a specific generic
+                        // implementation using something like
+                        // `to.MakeGenericMethod(typeof(string))`,
+                        // your hook will receive calls for all
+                        // reference type-based implementations out there.
+                        // However, since we do not patch the generic context
+                        // of the provided hook, it remains unchanged,
+                        // causing `typeof(T)` to defy users' expectations.
+                        //
+                        // So, TODO: patch the generic context of the detour target
+                        // and/or introduce a call filter based on the current context.
+
+                        // The generic context is passed as a pointer to a struct that
+                        // contains all the needed (?) information.
+                        // We can treat it as a simple `IntPtr`.
+                        genericContextPos = argumentTypes.Count;
+                        argumentTypes.Add(typeof(nint));
+                        break;
+
+                    case SpecialArgumentKind.UserArguments:
+                        userArgumentsOffset = argumentTypes.Count;
+                        argumentTypes.AddRange(parameters.Select(pi => canonicalize is null ? pi.ParameterType : canonicalize(pi.ParameterType)));
+                        break;
+                }
+            }
+
+            return argumentTypes.ToArray();
         }
     }
 }

--- a/src/MonoMod.Core/Platforms/Runtimes/Core100Runtime.cs
+++ b/src/MonoMod.Core/Platforms/Runtimes/Core100Runtime.cs
@@ -106,7 +106,7 @@ namespace MonoMod.Core.Platforms.Runtimes
             return runtimeMethodInfoStubCtorWrapper;
         }
 
-        protected override MethodInfo GetOrCreateGetTypeFromHandleUnsafe()
+        protected internal override MethodInfo GetOrCreateGetTypeFromHandleUnsafe()
         {
             var method = typeof(RuntimeTypeHandle)
                 .GetMethod("GetRuntimeTypeFromHandleMaybeNull", (BindingFlags)(-1), null, [typeof(IntPtr)], null);

--- a/src/MonoMod.Core/Platforms/Runtimes/Core21Runtime.cs
+++ b/src/MonoMod.Core/Platforms/Runtimes/Core21Runtime.cs
@@ -386,7 +386,7 @@ namespace MonoMod.Core.Platforms.Runtimes
         /// The internal call always exists, but the managed method doesn't in some cases.
         /// </summary>
         /// <returns></returns>
-        protected virtual MethodInfo GetOrCreateGetTypeFromHandleUnsafe()
+        protected internal virtual MethodInfo GetOrCreateGetTypeFromHandleUnsafe()
         {
             const string MethodName = "GetTypeFromHandleUnsafe";
             var method = typeof(Type).GetMethod(MethodName, (BindingFlags)(-1));

--- a/src/MonoMod.RuntimeDetour/Generics/AutoPrimeMode.cs
+++ b/src/MonoMod.RuntimeDetour/Generics/AutoPrimeMode.cs
@@ -1,0 +1,18 @@
+namespace MonoMod.RuntimeDetour.Generics
+{
+    /// <summary>
+    /// Controls automatic priming of generic-hook instantiations beyond those explicitly passed to <c>Prime</c>.
+    /// Reference positions vary per the chosen mode; value positions always match exactly, and a pure value-type
+    /// vector is unshared and never auto-caught. Reachability of value-type-containing vectors is runtime-dependent,
+    /// see <see cref="GenericHook.SupportsValueTypeAutoPrime"/>.
+    /// </summary>
+    public enum AutoPrimeMode
+    {
+        /// <summary>Only the instantiations explicitly passed to <c>Prime</c> are hooked.</summary>
+        None,
+        /// <summary>Also hook instantiations whose reference positions are assignable to a primed pattern.</summary>
+        Compatible,
+        /// <summary>Also hook every reference-position variation of a primed value signature.</summary>
+        All
+    }
+}

--- a/src/MonoMod.RuntimeDetour/Generics/GenericContextCaptureStub.cs
+++ b/src/MonoMod.RuntimeDetour/Generics/GenericContextCaptureStub.cs
@@ -1,0 +1,144 @@
+using MonoMod.Core.Platforms;
+using MonoMod.Utils;
+using System;
+
+namespace MonoMod.RuntimeDetour.Generics
+{
+    // Mono only. The managed dispatcher is a normal method: it can only read its declared arguments, not a physical
+    // register. But Mono passes the shared-generic context (RGCTX/MRGCTX) in a dedicated non-argument register
+    // (r10 on x86_64, x15 on Arm64) rather than as an argument, so the dispatcher can't see it.
+    // This stub copies that register into the argument register the dispatcher expects the context in, then jumps to
+    // the dispatcher.
+    internal sealed class GenericContextCaptureStub : IDisposable
+    {
+        private readonly IAllocatedMemory _alloc;
+        public IntPtr Address { get; private set; }
+
+        public GenericContextCaptureStub(IntPtr target, int integerArgRegisterIndex)
+        {
+            // Moves Mono's RGCTX/MRGCTX register into an argument register and jumps to the dispatcher.
+            var code = PlatformDetection.Architecture switch
+            {
+                ArchitectureKind.x86_64 => BuildX86_64(target, integerArgRegisterIndex),
+                ArchitectureKind.Arm64 => BuildArm64(target, integerArgRegisterIndex),
+                _ => throw new PlatformNotSupportedException(
+                    $"The Mono generic-context capture stub is only implemented for x86_64 and Arm64 (got {PlatformDetection.Architecture})."),
+            };
+
+            _alloc = AllocateExecutable(code);
+            Address = _alloc.BaseAddress;
+        }
+
+        internal static IAllocatedMemory AllocateExecutable(byte[] code)
+        {
+            var system = PlatformTriple.Current.System;
+            if (!system.MemoryAllocator.TryAllocate(new AllocationRequest(code.Length) { Executable = true }, out var alloc))
+            {
+                throw new InvalidOperationException("Could not allocate executable memory for a generic dispatch stub.");
+            }
+            system.PatchData(PatchTargetKind.Executable, alloc.BaseAddress, code, default);
+            return alloc;
+        }
+
+        // x86_64: Mono passes the RGCTX/MRGCTX in r10.
+        private static byte[] BuildX86_64(IntPtr target, int integerArgRegisterIndex)
+        {
+            var windows = PlatformDetection.OS is OSKind.Windows or OSKind.Wine;
+            byte[][] movFromR10ByIndex = windows
+                // Windows x64: rcx, rdx, r8, r9
+                ? [
+                    [0x4C, 0x89, 0xD1], // mov rcx, r10
+                    [0x4C, 0x89, 0xD2], // mov rdx, r10
+                    [0x4D, 0x89, 0xD0], // mov r8, r10
+                    [0x4D, 0x89, 0xD1], // mov r9, r10
+                ]
+                // SysV x64: rdi, rsi, rdx, rcx, r8, r9
+                : [
+                    [0x4C, 0x89, 0xD7], // mov rdi, r10
+                    [0x4C, 0x89, 0xD6], // mov rsi, r10
+                    [0x4C, 0x89, 0xD2], // mov rdx, r10
+                    [0x4C, 0x89, 0xD1], // mov rcx, r10
+                    [0x4D, 0x89, 0xD0], // mov r8, r10
+                    [0x4D, 0x89, 0xD1], // mov r9, r10
+                ];
+
+            if (integerArgRegisterIndex < 0 || integerArgRegisterIndex >= movFromR10ByIndex.Length)
+            {
+                throw new PlatformNotSupportedException($"The generic context cannot be captured into integer-argument register index {integerArgRegisterIndex} (it would be passed on the stack).");
+            }
+
+            // mov <argreg>, r10, from the index onward: the context is the dispatcher's last integer parameter,
+            // so registers past its index carry no arguments and overwriting them is harmless.
+            var movBytes = (movFromR10ByIndex.Length - integerArgRegisterIndex) * 3;
+            var code = new byte[movBytes + 12];
+            var i = 0;
+            for (var idx = integerArgRegisterIndex; idx < movFromR10ByIndex.Length; idx++)
+            {
+                movFromR10ByIndex[idx].CopyTo(code, i);
+                i += 3;
+            }
+            // mov rax, imm64
+            code[i++] = 0x48;
+            code[i++] = 0xB8;
+            BitConverter.GetBytes((long)target).CopyTo(code, i);
+            i += 8;
+            // jmp rax
+            code[i++] = 0xFF;
+            code[i] = 0xE0;
+            return code;
+        }
+
+        // Arm64: Mono's RGCTX/MRGCTX register is x15
+        // Integer args are x0..x7 and the return buffer is x8
+        private static byte[] BuildArm64(IntPtr target, int integerArgRegisterIndex)
+        {
+            const int paramRegs = 8;
+            if (integerArgRegisterIndex < 0 || integerArgRegisterIndex >= paramRegs)
+            {
+                throw new PlatformNotSupportedException($"The generic context cannot be captured into integer-argument register index {integerArgRegisterIndex} (it would be passed on the stack).");
+            }
+
+            // Copy x15 into the arg register(s) from the index onward (the context is the dispatcher's last integer
+            // parameter, so higher registers carry no arguments), then branch to `target`.
+            var movCount = paramRegs - integerArgRegisterIndex;
+            var code = new byte[(movCount * 4) + 4 + 4 + 8];
+            var pos = 0;
+
+            // orr x<d>, xzr, x15
+            for (var d = integerArgRegisterIndex; d < paramRegs; d++)
+            {
+                WriteUInt32LittleEndian(code, pos, 0xAA0F03E0u | (uint)d);
+                pos += 4;
+            }
+
+            // ldr x16, #8
+            WriteUInt32LittleEndian(code, pos, 0x58000050u);
+            pos += 4;
+            // br x16
+            WriteUInt32LittleEndian(code, pos, 0xD61F0200u);
+            pos += 4;
+            // .quad target
+            BitConverter.GetBytes((long)target).CopyTo(code, pos);
+
+            return code;
+        }
+
+        internal static void WriteUInt32LittleEndian(byte[] buffer, int offset, uint value)
+        {
+            buffer[offset + 0] = (byte)(value & 0xFF);
+            buffer[offset + 1] = (byte)((value >> 8) & 0xFF);
+            buffer[offset + 2] = (byte)((value >> 16) & 0xFF);
+            buffer[offset + 3] = (byte)((value >> 24) & 0xFF);
+        }
+
+        public void Dispose()
+        {
+            if (Address == IntPtr.Zero)
+            {
+                return;
+            }
+            Address = IntPtr.Zero;
+            _alloc.Dispose();
+        }
+    }
+}

--- a/src/MonoMod.RuntimeDetour/Generics/GenericContextReader.cs
+++ b/src/MonoMod.RuntimeDetour/Generics/GenericContextReader.cs
@@ -1,0 +1,534 @@
+﻿using MonoMod.Core.Interop;
+using MonoMod.Core.Platforms;
+using MonoMod.Core.Platforms.Runtimes;
+using MonoMod.Utils;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Reflection.Emit;
+
+namespace MonoMod.RuntimeDetour.Generics
+{
+    /// <summary>
+    /// Reconstructs the full type-argument vector (declaring-type args ++ method args) of a shared
+    /// generic call from its runtime generic context.
+    /// </summary>
+    internal static unsafe class GenericContextReader
+    {
+        // Ordered list of candidate MethodTable*/TypeHandle -> Type resolvers.
+        // Runtime versions expose different internal helpers, so pick whichever actually works
+        private static readonly List<Func<IntPtr, Type?>> handleToTypeResolvers = BuildHandleToTypeResolvers();
+        private static readonly HandleToMethod? HandleToMethodImpl = TryBuildHandleToMethod();
+
+        public static Type[] FromMethodDesc(IntPtr methodDesc)
+        {
+            if (methodDesc == IntPtr.Zero)
+            {
+                throw new ArgumentNullException(nameof(methodDesc));
+            }
+
+            if (!IsPlausibleRuntimePointer(methodDesc))
+            {
+                throw new ArgumentException($"Generic context 0x{methodDesc.ToInt64():x} is not a plausible MethodDesc pointer.", nameof(methodDesc));
+            }
+
+            var declaringMt = ReadDeclaringMethodTable(methodDesc);
+
+            if (HandleToMethodImpl is not null)
+            {
+                var mb = HandleToMethodImpl(methodDesc, declaringMt) ?? throw new InvalidOperationException("Could not resolve MethodDesc to a MethodBase.");
+                var declA = mb.DeclaringType is { IsGenericType: true } dt ? dt.GetGenericArguments() : Type.EmptyTypes;
+                var methA = mb.IsGenericMethod ? mb.GetGenericArguments() : Type.EmptyTypes;
+                return [.. declA, .. methA];
+            }
+            // .NET 5, 6, .NET Framework, .NET Core
+            var md = (Fx.V48.MethodDesc*)methodDesc;
+            var declaringType = RequireType(declaringMt);
+            var methodArgs = md->TryAsInstantiated(out var imd) && imd->IMD_HasMethodInstantiation
+                ? ReadHandles((IntPtr*)imd->m_pPerInstInfo, imd->m_wNumGenericArgs)
+                : Type.EmptyTypes;
+            var declArgs = declaringType.IsGenericType ? declaringType.GetGenericArguments() : Type.EmptyTypes;
+            return [.. declArgs, .. methodArgs];
+        }
+
+        // Only reachable on Framework/CoreCLR
+        private static IntPtr ReadDeclaringMethodTable(IntPtr methodDesc) => PlatformDetection.Runtime switch
+        {
+            RuntimeKind.Framework => (IntPtr)(void*)((Fx.V48.MethodDesc*)methodDesc)->MethodTable,
+            RuntimeKind.CoreCLR => (IntPtr)(void*)((CoreCLR.V60.MethodDesc*)methodDesc)->MethodTable,
+            _ => throw new NotImplementedException($"Reading Generic Context not implemented on {PlatformDetection.Runtime}."),
+        };
+
+        public static Type[] FromMethodTable(IntPtr methodTable)
+        {
+            if (methodTable == IntPtr.Zero)
+            {
+                throw new ArgumentNullException(nameof(methodTable));
+            }
+            if (!IsPlausibleRuntimePointer(methodTable))
+            {
+                throw new ArgumentException($"Generic context 0x{methodTable.ToInt64():x} is not a plausible MethodTable pointer.", nameof(methodTable));
+            }
+            var t = RequireType(methodTable);
+            return t.IsGenericType ? t.GetGenericArguments() : Type.EmptyTypes;
+        }
+
+        public static Type[] FromThisObject(object self, MethodBase openSource)
+        {
+            Helpers.ThrowIfArgumentNull(self);
+            Helpers.ThrowIfArgumentNull(openSource);
+            return TypeArgsForDeclaringType(self.GetType(), openSource);
+        }
+
+        private static Type[] TypeArgsForDeclaringType(Type runtimeType, MethodBase openSource)
+        {
+            var openDecl = openSource.DeclaringType;
+            Helpers.Assert(openDecl != null, "Open source has no declaring type.");
+            var def = openDecl.IsGenericType ? openDecl.GetGenericTypeDefinition() : openDecl;
+
+            for (var t = runtimeType; t is not null; t = t.BaseType)
+            {
+                if ((t.IsGenericType && t.GetGenericTypeDefinition() == def) || t == def)
+                {
+                    return t.IsGenericType ? t.GetGenericArguments() : Type.EmptyTypes;
+                }
+            }
+
+            throw new InvalidOperationException($"Could not find {def} in the hierarchy of {runtimeType}.");
+        }
+
+
+        private static Type[] ReadHandles(IntPtr* handles, int n)
+        {
+            if (n == 0 || handles is null)
+            {
+                return Type.EmptyTypes;
+            }
+
+            var result = new Type[n];
+            for (var i = 0; i < n; i++)
+            {
+                result[i] = RequireType(handles[i]);
+            }
+
+            return result;
+        }
+
+        private static Type RequireType(IntPtr handle)
+            => TryResolveType(handle) ?? throw new InvalidOperationException($"Unresolvable type handle 0x{handle:x}.");
+
+        // Trying to dereference a wrong pointer can cause a host crash; so validate here
+        private static bool IsPlausibleRuntimePointer(IntPtr p)
+            => (p.ToInt64() & (IntPtr.Size - 1)) == 0 && (ulong)p.ToInt64() >= 0x10000UL;
+
+        // Tries each candidate resolver until one returns a Type without faulting
+        private static Func<IntPtr, Type?>? winningResolver;
+
+        private static Type? TryResolveType(IntPtr handle)
+        {
+            if (handle == IntPtr.Zero)
+            {
+                return null;
+            }
+
+            if (winningResolver is { } winner)
+            {
+                try
+                {
+                    var t = winner(handle);
+                    if (t is not null)
+                    {
+                        return t;
+                    }
+                }
+                catch
+                {
+                    // The previously-working resolver faulted on this handle?
+                }
+            }
+
+            Exception? last = null;
+            foreach (var resolver in handleToTypeResolvers)
+            {
+                try
+                {
+                    var t = resolver(handle);
+                    if (t is not null)
+                    {
+                        winningResolver = resolver;
+                        return t;
+                    }
+                }
+                catch (Exception e)
+                {
+                    last = e;
+                }
+            }
+
+            if (last is not null)
+            {
+                MMDbgLog.Trace($"All type-handle resolvers failed for 0x{handle:x}: {last.Message}");
+            }
+            return null;
+        }
+
+        private static List<Func<IntPtr, Type?>> BuildHandleToTypeResolvers()
+        {
+            List<Func<IntPtr, Type?>> resolvers = [];
+
+            // 1. CoreCLR .NET 7+: the supported public RuntimeTypeHandle.FromIntPtr + Type.GetTypeFromHandle.
+            var fromIntPtr = typeof(RuntimeTypeHandle).GetMethod("FromIntPtr", StaticFlags, null, [typeof(IntPtr)], null);
+            if (fromIntPtr is not null)
+            {
+                var conv = (Func<IntPtr, RuntimeTypeHandle>)Delegate.CreateDelegate(typeof(Func<IntPtr, RuntimeTypeHandle>), fromIntPtr);
+                resolvers.Add(h => Type.GetTypeFromHandle(conv(h)));
+            }
+
+            // 2. Mono: Type.internal_from_handle (or a reinterpret of the handle as a RuntimeTypeHandle).
+            if (PlatformDetection.Runtime == RuntimeKind.Mono)
+            {
+                var monoFromHandle = typeof(Type).GetMethod("internal_from_handle", StaticFlags, null, [typeof(IntPtr)], null);
+                if (monoFromHandle is not null)
+                {
+                    resolvers.Add((Func<IntPtr, Type?>)Delegate.CreateDelegate(typeof(Func<IntPtr, Type?>), monoFromHandle));
+                }
+                else
+                {
+                    resolvers.Add(static h => Type.GetTypeFromHandle(Unsafe.As<IntPtr, RuntimeTypeHandle>(ref h)));
+                }
+            }
+
+            // 3 & 4. CoreCLR .NET 5/6 (and any version where FromIntPtr is unavailable): the internal
+            // Type.GetTypeFromHandleUnsafe FCall, reached through a wrapper. It can fault; try CoreLib and this module as owners
+            if (PlatformTriple.Current.Runtime is Core21Runtime core21 && core21.GetOrCreateGetTypeFromHandleUnsafe() is MethodInfo unsafeFromHandle)
+            {
+                Type?[] owners = [typeof(object), null];
+                foreach (var owner in owners)
+                {
+                    try
+                    {
+                        resolvers.Add(BuildGetTypeFromHandleUnsafeWrapper(unsafeFromHandle, owner));
+                    }
+                    catch { }
+                }
+            }
+
+            // 5. .NET Framework (and anything exposing Type.GetTypeFromHandleUnsafe directly as a delegate target).
+            var unsafeM = typeof(Type).GetMethod("GetTypeFromHandleUnsafe", StaticFlags, null, [typeof(IntPtr)], null);
+            if (unsafeM is not null)
+            {
+                try
+                {
+                    resolvers.Add((Func<IntPtr, Type?>)Delegate.CreateDelegate(typeof(Func<IntPtr, Type?>), unsafeM));
+                }
+                catch { }
+            }
+
+            if (resolvers.Count == 0)
+            {
+                throw new PlatformNotSupportedException($"{PlatformDetection.OS}, {PlatformDetection.Architecture}, {PlatformDetection.Runtime}: No way to turn handle to type.");
+            }
+
+            return resolvers;
+        }
+
+        private static Func<IntPtr, Type?> BuildGetTypeFromHandleUnsafeWrapper(MethodInfo target, Type? owner)
+        {
+            // Host the wrapper either in CoreLib (owner != null) or this module (owner == null).
+            var dm = owner is not null
+                ? new DynamicMethod("GetTypeFromHandleUnsafe_Wrapper", typeof(Type), [typeof(IntPtr)], owner, true)
+                : new DynamicMethod("GetTypeFromHandleUnsafe_Wrapper", typeof(Type), [typeof(IntPtr)], typeof(GenericContextReader).Module, true);
+            var il = dm.GetILGenerator();
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Call, target);
+            il.Emit(OpCodes.Ret);
+            return (Func<IntPtr, Type?>)dm.CreateDelegate(typeof(Func<IntPtr, Type?>));
+        }
+
+        private delegate MethodBase? HandleToMethod(IntPtr md, IntPtr declaringMt);
+
+        private const BindingFlags StaticFlags = BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic;
+        private const BindingFlags InstanceFlags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
+        private static HandleToMethod? TryBuildHandleToMethod()
+        {
+            var mhFromIntPtr = typeof(RuntimeMethodHandle).GetMethod("FromIntPtr", StaticFlags, null, [typeof(IntPtr)], null);
+            var thFromIntPtr = typeof(RuntimeTypeHandle).GetMethod("FromIntPtr", StaticFlags, null, [typeof(IntPtr)], null);
+
+            var getFromHandle = typeof(MethodBase).GetMethod(nameof(MethodBase.GetMethodFromHandle), StaticFlags, null, [typeof(RuntimeMethodHandle), typeof(RuntimeTypeHandle)], null);
+            Helpers.Assert(getFromHandle != null);
+            var getter = (Func<RuntimeMethodHandle, RuntimeTypeHandle, MethodBase?>)Delegate.CreateDelegate(typeof(Func<RuntimeMethodHandle, RuntimeTypeHandle, MethodBase?>), getFromHandle);
+
+            var getFromHandle1 = typeof(MethodBase).GetMethod(nameof(MethodBase.GetMethodFromHandle), StaticFlags, null, [typeof(RuntimeMethodHandle)], null);
+            var getter1 = getFromHandle1 is null
+                ? null
+                : (Func<RuntimeMethodHandle, MethodBase?>)Delegate.CreateDelegate(typeof(Func<RuntimeMethodHandle, MethodBase?>), getFromHandle1);
+
+            if (mhFromIntPtr is null || thFromIntPtr is null)
+            {
+                if (PlatformDetection.Runtime == RuntimeKind.Mono)
+                {
+                    return BuildMonoHandleToMethod();
+                }
+                if (PlatformDetection.Runtime == RuntimeKind.Framework)
+                {
+                    return null;
+                }
+
+                // https://github.com/dotnet/dotnet/blob/b0f34d51fccc69fd334253924abd8d6853fad7aa/src/runtime/src/coreclr/System.Private.CoreLib/src/System/RuntimeHandles.cs#L1018
+                // IntPtr value => new RuntimeMethodHandle(new RuntimeMethodInfoStub(new RuntimeMethodHandleInternal(value), keepAlive))
+                createHandle = BuildCustomHandleToMethod();
+                return (md, declMt) =>
+                {
+                    // Prefer resolving from the method handle alone: it avoids converting the declaring MethodTable*
+                    // into a Type via GetTypeFromHandleUnsafe, which faults on some .NET 5/6 builds.
+                    // It can throw generic declaring types
+                    if (getter1 is not null)
+                    {
+                        try
+                        {
+                            var resolved = getter1(createHandle!(md, handleKeepAlive));
+                            if (resolved is not null)
+                            {
+                                return resolved;
+                            }
+                        }
+                        catch (Exception e)
+                        {
+                            MMDbgLog.Trace($"Handle-only resolve failed, falling back to declaring-type path: {e.Message}");
+                        }
+                    }
+
+                    var t = RequireType(declMt);
+                    return getter(createHandle!(md, t), t.TypeHandle);
+                };
+            }
+
+            var mhConv = (Func<IntPtr, RuntimeMethodHandle>)Delegate.CreateDelegate(typeof(Func<IntPtr, RuntimeMethodHandle>), mhFromIntPtr);
+            var thConv = (Func<IntPtr, RuntimeTypeHandle>)Delegate.CreateDelegate(typeof(Func<IntPtr, RuntimeTypeHandle>), thFromIntPtr);
+
+            return (md, declMt) => getter(mhConv(md), thConv(declMt));
+        }
+        private delegate RuntimeMethodHandle CreateHandleDelegate(IntPtr mD, object keepAlive);
+        private static CreateHandleDelegate? createHandle;
+        private static readonly object handleKeepAlive = new();
+        private static CreateHandleDelegate? BuildCustomHandleToMethod()
+        {
+            var t_RuntimeMethodHandleInternal = Type.GetType("System.RuntimeMethodHandleInternal");
+            var t_IRuntimeMethodInfo = Type.GetType("System.IRuntimeMethodInfo");
+            var t_RuntimeMethodInfoStub = Type.GetType("System.RuntimeMethodInfoStub");
+
+            if (t_RuntimeMethodHandleInternal == null || t_IRuntimeMethodInfo == null || t_RuntimeMethodInfoStub == null)
+                throw new InvalidOperationException("Required internal runtime types not found.");
+
+            var ctor_mdHandle = t_RuntimeMethodHandleInternal.GetConstructor(InstanceFlags, null, [typeof(IntPtr)], null);
+            var ctor_stub = t_RuntimeMethodInfoStub.GetConstructor(InstanceFlags, null, [t_RuntimeMethodHandleInternal, typeof(object)], null);
+            var ctor_rmh = typeof(RuntimeMethodHandle).GetConstructor(InstanceFlags, null, [t_IRuntimeMethodInfo], null);
+
+            if (ctor_mdHandle == null || ctor_stub == null || ctor_rmh == null)
+                throw new InvalidOperationException("Required internal constructors not found.");
+
+            var dm = new DynamicMethod("CreateRuntimeMethodHandle", typeof(RuntimeMethodHandle), [typeof(IntPtr), typeof(object)], typeof(GenericContextReader).Module, skipVisibility: true);
+
+            var il = dm.GetILGenerator();
+
+            il.Emit(OpCodes.Ldarg_0);               // IntPtr methodDesc
+            il.Emit(OpCodes.Newobj, ctor_mdHandle); // new RuntimeMethodHandleInternal(methodDesc)
+            il.Emit(OpCodes.Ldarg_1);               // object keepAlive
+            il.Emit(OpCodes.Newobj, ctor_stub);     // new RuntimeMethodInfoStub(handle, keepAlive)
+            il.Emit(OpCodes.Newobj, ctor_rmh);      // new RuntimeMethodHandle(stub)
+            il.Emit(OpCodes.Ret);
+
+            return (CreateHandleDelegate)dm.CreateDelegate(typeof(CreateHandleDelegate));
+        }
+
+        private static HandleToMethod? BuildMonoHandleToMethod()
+        {
+            const BindingFlags F = BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic;
+
+            var noCheck = typeof(MethodBase).GetMethod("GetMethodFromHandleNoGenericCheck", F, null, [typeof(RuntimeMethodHandle)], null);
+
+            if (noCheck is not null)
+            {
+                var f = (Func<RuntimeMethodHandle, MethodBase?>)Delegate.CreateDelegate(typeof(Func<RuntimeMethodHandle, MethodBase?>), noCheck);
+                return (md, _) => f(Unsafe.As<IntPtr, RuntimeMethodHandle>(ref md));
+            }
+
+            return (md, _) => MethodBase.GetMethodFromHandle(Unsafe.As<IntPtr, RuntimeMethodHandle>(ref md));
+        }
+
+        public enum GenericContextKind
+        {
+            MethodDesc,
+            MethodTable,
+            ThisObject
+        }
+
+        public static GenericContextKind ClassifyContext(MethodBase m)
+        {
+            Helpers.ThrowIfArgumentNull(m);
+
+            // https://www.mono-project.com/docs/advanced/runtime/docs/generic-sharing/
+
+            // Generic methods get a MethodDesc encoding both class and method args
+            if (m.IsGenericMethod)
+            {
+                return GenericContextKind.MethodDesc;
+            }
+
+            // non-generic non-static method on a generic reference type -> context is the table behind `this`
+            if (!m.IsStatic && m.DeclaringType is { IsValueType: false })
+            {
+                return GenericContextKind.ThisObject;
+            }
+
+            return GenericContextKind.MethodTable;
+        }
+
+        // The ThisObject kind never reaches Read: those bodies dispatch through FromThisObject with a real,
+        // GC-tracked object reference.
+        public static Type[] Read(IntPtr context, GenericContextKind kind, MethodBase openSource)
+        {
+            Helpers.ThrowIfArgumentNull(openSource);
+
+            if (PlatformDetection.Runtime == RuntimeKind.Mono)
+            {
+                return FromMonoRgctx(context, kind, openSource);
+            }
+
+            return kind switch
+            {
+                GenericContextKind.MethodDesc => FromMethodDesc(context),
+                GenericContextKind.MethodTable => FromMethodTable(context),
+                _ => throw new ArgumentOutOfRangeException(nameof(kind)),
+            };
+        }
+
+        private static Type[] FromMonoRgctx(IntPtr context, GenericContextKind kind, MethodBase openSource)
+        {
+            if (context == IntPtr.Zero)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            var declType = openSource.DeclaringType;
+
+            if (kind == GenericContextKind.MethodDesc)
+            {
+                // MRGCTX layout begins: { MonoVTable* class_vtable; MonoGenericInst* method_inst; ... }
+                // https://github.com/mono/mono/blob/main/mono/mini/mini.h#L1078
+                var classVtable = *(IntPtr*)context;
+                var methodInst = *(IntPtr*)((nint)context + IntPtr.Size);
+                var methodArgs = ReadMonoGenericInst(methodInst);
+
+                if (declType?.IsGenericType ?? false)
+                {
+                    var classArgs = ClassArgsFromVTable(classVtable, declType!);
+                    return [.. classArgs, .. methodArgs];
+                }
+                else
+                {
+                    return methodArgs;
+                }
+            }
+
+            return ClassArgsFromVTable(context, declType ?? throw new InvalidOperationException("No declaring type."));
+        }
+
+        private static Type[] ClassArgsFromVTable(IntPtr vtable, Type declType)
+        {
+            if (vtable == IntPtr.Zero)
+            {
+                throw new ArgumentNullException(nameof(vtable));
+            }
+
+            var t = MonoTypeFromVTable(vtable);
+
+            var def = declType.IsGenericType ? declType.GetGenericTypeDefinition() : declType;
+            for (var cur = t; cur is not null; cur = cur.BaseType)
+            {
+                if ((cur.IsGenericType && cur.GetGenericTypeDefinition() == def) || cur == def)
+                {
+                    return cur.IsGenericType ? cur.GetGenericArguments() : Type.EmptyTypes;
+                }
+            }
+
+            throw new InvalidOperationException($"Could not find {def} in hierarchy of {t}.");
+        }
+
+        private static Type[] ReadMonoGenericInst(IntPtr inst)
+        {
+            if (inst == IntPtr.Zero)
+            {
+                return Type.EmptyTypes;
+            }
+            // Assumes MONO_SMALL_CONFIG is not defined
+            // TODO: handle other layouts? https://github.com/mono/mono/blob/main/mono/metadata/class-internals.h#L406
+            var argc = (*(uint*)((nint)inst + 4) & 0x3FFFFFu); // Reads the first 22 bits representing argc
+            if (argc == 0)
+            {
+                return Type.EmptyTypes;
+            }
+
+            var argv = (IntPtr*)((nint)inst + 8);
+            var result = new Type[argc];
+            for (var i = 0; i < argc; i++)
+            {
+                result[i] = RequireType(argv[i]);
+            }
+
+            return result;
+        }
+        // MonoVTable.klass is the first field (offset 0)
+        // https://github.com/mono/mono/blob/main/mono/metadata/class-internals.h#L360
+        private static Type? MonoTypeFromVTable(IntPtr vtable)
+        {
+            var klass = *(IntPtr*)vtable;
+            Helpers.Assert(klass != IntPtr.Zero);
+            return MonoClassToType(klass);
+        }
+        // mono_class_get_type
+        private static IntPtr monoClassGetType;
+        private static bool monoResolveAttempted;
+
+        private static IntPtr MonoClassGetTypePtr()
+        {
+            if (monoResolveAttempted)
+            {
+                return monoClassGetType;
+            }
+
+            monoResolveAttempted = true;
+
+            // Globally visible symbol?
+            if (DynDll.TryOpenLibrary(null, out var main) && main.TryGetExport("mono_class_get_type", out var p) && p != IntPtr.Zero)
+            {
+                return monoClassGetType = p;
+            }
+
+            // In its own module
+            string[] libs = ["mono-2.0-bdwgc", "mono-2.0-sgen", "mono-2.0-boehm", "monobdwgc-2.0", "monosgen-2.0", "mono-2.0", "mono"];
+            foreach (var lib in libs)
+            {
+                if (DynDll.TryOpenLibrary(lib, out var h) &&
+                    h.TryGetExport("mono_class_get_type", out var fp) && fp != IntPtr.Zero)
+                {
+                    return monoClassGetType = fp;
+                }
+            }
+
+            throw new PlatformNotSupportedException($"{PlatformDetection.OS}, {PlatformDetection.Architecture}, {PlatformDetection.Runtime}: mono_class_get_type not found");
+        }
+
+        private static Type? MonoClassToType(IntPtr klass)
+        {
+            var fnptr = MonoClassGetTypePtr();
+
+            // MonoType*
+            var monoType = ((delegate* unmanaged[Cdecl]<IntPtr, IntPtr>)fnptr)(klass);
+            Helpers.Assert(monoType != IntPtr.Zero);
+
+            // Same MonoType* -> internal_from_handle
+            return TryResolveType(monoType);
+        }
+    }
+}

--- a/src/MonoMod.RuntimeDetour/Generics/GenericHelper.cs
+++ b/src/MonoMod.RuntimeDetour/Generics/GenericHelper.cs
@@ -1,0 +1,60 @@
+using MonoMod.Core.Platforms;
+using MonoMod.Utils;
+using System;
+using System.Linq;
+using System.Reflection;
+
+namespace MonoMod.RuntimeDetour.Generics
+{
+    public static class GenericHelper
+    {
+        internal static bool IsContextForwarded(GenericContextReader.GenericContextKind kind)
+            => kind != GenericContextReader.GenericContextKind.ThisObject && PlatformDetection.Runtime != RuntimeKind.Mono;
+
+        internal static bool HasReturnBuffer(Type returnType) 
+            => returnType != typeof(void) && PlatformTriple.Current.Abi.Classify(returnType, true) is TypeClassification.ByReference;
+
+        /// <summary>True if this concrete type participates in reference-type code sharing.</summary>
+        public static bool TypeIsShared(Type type)
+        {
+            Helpers.ThrowIfArgumentNull(type);
+            if (type.ContainsGenericParameters)
+            {
+                throw new InvalidOperationException("Cannot classify an open generic type.");
+            }
+
+            if (type.IsPrimitive)
+            {
+                return false;
+            }
+
+            if (type.IsValueType)
+            {
+                return type.IsGenericType && type.GetGenericArguments().Any(TypeIsShared);
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// True if the concrete method routes through shared code (i.e. its real type
+        /// arguments are only recoverable from a hidden generic context at runtime).
+        /// </summary>
+        public static bool MethodIsShared(MethodBase method)
+        {
+            Helpers.ThrowIfArgumentNull(method);
+            var dt = method.DeclaringType;
+            if (dt is { IsGenericType: true } && !dt.ContainsGenericParameters && dt.GetGenericArguments().Any(TypeIsShared))
+            {
+                return true;
+            }
+
+            if (method.IsGenericMethod && !method.ContainsGenericParameters && method.GetGenericArguments().Any(TypeIsShared))
+            {
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/MonoMod.RuntimeDetour/Generics/GenericHook.cs
+++ b/src/MonoMod.RuntimeDetour/Generics/GenericHook.cs
@@ -1,0 +1,134 @@
+using MonoMod.Core;
+using MonoMod.Utils;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace MonoMod.RuntimeDetour.Generics
+{
+    public class GenericHook : IDisposable
+    {
+        /// <summary>
+        /// Whether value-type-containing instantiations (e.g. <c>&lt;TRef, int&gt;</c>) can be auto-discovered on the
+        /// current runtime. <see langword="false"/> on Mono gsharedvt context is unreadable
+        /// Explicit <see cref="Prime"/> works everywhere.
+        /// </summary>
+        public static bool SupportsValueTypeAutoPrime { get; } = PlatformDetection.Runtime != RuntimeKind.Mono;
+
+        private readonly MethodBase openSource;
+        private readonly MethodInfo openTarget;
+        private readonly DetourConfig? config;
+        private readonly IDetourFactory factory;
+        private readonly SharedBodyDispatcher dispatcher;
+        private readonly object _lock = new();
+
+        // Enumerated lock-free on the dispatch path while Prime can add concurrently.
+        internal readonly ConcurrentDictionary<InstantiationKey, byte> Primed = [];
+        private readonly Dictionary<InstantiationKey, Hook> unshared = [];
+        private bool disposed;
+
+        /// <summary>
+        /// Detours a generic source with the target.
+        /// </summary>
+        /// <param name="openSource">The open source method, e.g. A&lt;T&gt; (not a closed instantiation like A&lt;int&gt;!)</param>
+        /// <param name="openTarget">The open target method, e.g. B&lt;T&gt; (not a closed instantiation like B&lt;int&gt;!)</param>
+        /// <param name="primedTypes">The type-argument vectors to hook initially; more can be added via <see cref="Prime"/>.</param>
+        /// <param name="autoPrime">Whether instantiations beyond <paramref name="primedTypes"/> are hooked automatically.</param>
+        /// <param name="config">Only used for unshared instantiations</param>
+        /// <param name="factory">Only used for unshared instantiations</param>
+        /// <exception cref="ArgumentException"><paramref name="openSource"/> is not an open generic method.</exception>
+        public GenericHook(MethodBase openSource, MethodInfo openTarget, IEnumerable<Type[]>? primedTypes = null, AutoPrimeMode autoPrime = AutoPrimeMode.None, DetourConfig? config = null, IDetourFactory? factory = null)
+        {
+            Helpers.ThrowIfArgumentNull(openSource);
+            Helpers.ThrowIfArgumentNull(openTarget);
+            if (!openSource.ContainsGenericParameters)
+            {
+                throw new ArgumentException("Source must be an open generic.", nameof(openSource));
+            }
+
+            this.openSource = openSource;
+            this.openTarget = openTarget;
+            this.config = config;
+            this.factory = factory ?? DetourFactory.Current;
+            dispatcher = new SharedBodyDispatcher(openSource, autoPrime, this);
+
+            if (primedTypes is not null)
+            {
+                foreach (var vec in primedTypes)
+                {
+                    Prime(vec);
+                }
+            }
+        }
+
+        public void Prime(params Type[] typeArgs)
+        {
+            var key = new InstantiationKey(typeArgs);
+            Primed[key] = 0;
+            try
+            {
+                OnDiscovered(key);
+            }
+            catch
+            {
+                Primed.TryRemove(key, out _);
+                throw;
+            }
+        }
+
+        internal void OnDiscovered(InstantiationKey key)
+        {
+            // Lock order is always GenericHook._lock -> SharedBodyDispatcher._lock.
+            lock (_lock)
+            {
+                if (disposed || unshared.ContainsKey(key) || dispatcher.Contains(key))
+                {
+                    return;
+                }
+
+                var (closedSrc, closedTgt) = GenericInstantiator.Close(openSource, openTarget, key.TypeArguments);
+
+                if (!GenericHelper.MethodIsShared(closedSrc))
+                {
+                    // Unshared: owns its native body, a normal Hook works.
+                    var hook = new Hook(closedSrc, closedTgt, null, factory, config, true, true);
+                    unshared.Add(key, hook);
+                }
+                else
+                {
+                    dispatcher.Register(key, closedSrc, closedTgt, TargetWantsOrig(closedSrc, closedTgt));
+                }
+            }
+        }
+
+        // One extra leading param on the target => it's the orig delegate
+        private static bool TargetWantsOrig(MethodBase src, MethodInfo tgt)
+        {
+            var srcSig = MethodSignature.ForMethod(src);
+            var dstSig = MethodSignature.ForMethod(tgt, true);
+            return dstSig.ParameterCount == srcSig.ParameterCount + 1;
+        }
+
+        public void Dispose()
+        {
+            lock (_lock)
+            {
+                if (disposed)
+                {
+                    return;
+                }
+
+                disposed = true;
+
+                foreach (var h in unshared.Values)
+                {
+                    h.Dispose();
+                }
+
+                unshared.Clear();
+                dispatcher.Dispose();
+            }
+        }
+    }
+}

--- a/src/MonoMod.RuntimeDetour/Generics/GenericInstantiator.cs
+++ b/src/MonoMod.RuntimeDetour/Generics/GenericInstantiator.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+
+namespace MonoMod.RuntimeDetour.Generics
+{
+    internal static class GenericInstantiator
+    {
+        private const BindingFlags AllDecl = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance | BindingFlags.DeclaredOnly;
+
+        /// <summary>
+        /// Given the open source/target and a full type-argument vector, returns the concrete pair.
+        /// Vector layout: [declaringType args ..., method args ...].
+        /// </summary>
+        public static (MethodBase Source, MethodInfo Target) Close(MethodBase openSource, MethodInfo openTarget, Type[] typeArgs)
+        {
+            var closedSource = CloseSource(openSource, typeArgs);
+
+            if (!openTarget.IsGenericMethodDefinition ||
+                openTarget.GetGenericArguments().Length != typeArgs.Length)
+            {
+                throw new ArgumentException("Target must be an open generic method whose arity equals the source's (declaring-type args + method args).", nameof(openTarget));
+            }
+
+            return (closedSource, openTarget.MakeGenericMethod(typeArgs));
+        }
+
+        /// <summary>
+        /// Closes just the open source over a full type-argument vector (declaring-type args ++ method args).
+        /// </summary>
+        public static MethodBase CloseSource(MethodBase openSource, Type[] typeArgs)
+        {
+            var declDef = openSource.DeclaringType;
+            if (declDef is { IsGenericType: true, IsGenericTypeDefinition: false })
+            {
+                declDef = declDef.GetGenericTypeDefinition();
+            }
+
+            var declArity = declDef is { IsGenericTypeDefinition: true } ? declDef.GetGenericArguments().Length : 0;
+            var methodArity = openSource.IsGenericMethodDefinition ? openSource.GetGenericArguments().Length : 0;
+
+            if (typeArgs.Length != declArity + methodArity)
+            {
+                throw new ArgumentException($"Source needs {declArity + methodArity} type args, got {typeArgs.Length}.", nameof(typeArgs));
+            }
+
+            var declArgs = typeArgs.Take(declArity).ToArray();
+            var methodArgs = typeArgs.Skip(declArity).ToArray();
+
+            var srcOnType = declArity > 0
+                ? ResolveOnClosedType(openSource, declDef!.MakeGenericType(declArgs))
+                : openSource;
+
+            return methodArity > 0 ? ((MethodInfo)srcOnType).MakeGenericMethod(methodArgs) : srcOnType;
+        }
+
+        private static MethodBase ResolveOnClosedType(MethodBase openDef, Type closedType)
+        {
+            if (openDef is ConstructorInfo)
+            {
+                foreach (var c in closedType.GetConstructors(AllDecl))
+                {
+                    if (c.MetadataToken == openDef.MetadataToken && c.Module == openDef.Module)
+                    {
+                        return c;
+                    }
+                }
+            }
+            else
+            {
+                foreach (var m in closedType.GetMethods(AllDecl))
+                {
+                    if (m.MetadataToken == openDef.MetadataToken && m.Module == openDef.Module)
+                    {
+                        return m;
+                    }
+                }
+            }
+            throw new MissingMethodException($"Could not locate {openDef} on {closedType}.");
+        }
+    }
+}

--- a/src/MonoMod.RuntimeDetour/Generics/GenericOrigCloner.cs
+++ b/src/MonoMod.RuntimeDetour/Generics/GenericOrigCloner.cs
@@ -1,0 +1,51 @@
+using MonoMod.Utils;
+using System;
+using System.Reflection;
+
+namespace MonoMod.RuntimeDetour.Generics
+{
+    internal sealed class GenericOrigCloner : IDisposable
+    {
+        private readonly DynamicMethodDefinition dmd;
+
+        public MethodInfo Method { get; }
+
+        private GenericOrigCloner(DynamicMethodDefinition dmd, MethodInfo generated)
+        {
+            this.dmd = dmd;
+            Method = generated;
+        }
+
+        public static GenericOrigCloner Create(MethodBase closedSource)
+        {
+            Helpers.ThrowIfArgumentNull(closedSource);
+            if (closedSource.ContainsGenericParameters)
+            {
+                throw new ArgumentException("closedSource must be a fully closed instantiation.", nameof(closedSource));
+            }
+
+            var dmd = new DynamicMethodDefinition(closedSource);
+            try
+            {
+                return new GenericOrigCloner(dmd, dmd.Generate());
+            }
+            catch
+            {
+                dmd.Dispose();
+                throw;
+            }
+        }
+
+        public Delegate CreateDelegate(Type delegateType)
+        {
+            if (!typeof(Delegate).IsAssignableFrom(delegateType))
+            {
+                throw new ArgumentException($"{delegateType} is not a delegate type.", nameof(delegateType));
+            }
+
+            return Method.CreateDelegate(delegateType);
+        }
+
+        public void Dispose() => dmd.Dispose();
+    }
+}

--- a/src/MonoMod.RuntimeDetour/Generics/InstantiationKey.cs
+++ b/src/MonoMod.RuntimeDetour/Generics/InstantiationKey.cs
@@ -1,0 +1,91 @@
+﻿using System;
+
+namespace MonoMod.RuntimeDetour.Generics
+{
+    /// <summary>
+    /// A full type-argument vector for one closed instantiation:
+    /// declaring-type arguments followed by method arguments.
+    /// </summary>
+    public readonly struct InstantiationKey : IEquatable<InstantiationKey>
+    {
+        public Type[] TypeArguments { get; }
+        public InstantiationKey(Type[] typeArguments) => TypeArguments = typeArguments;
+
+        public bool Equals(InstantiationKey other)
+        {
+            var a = TypeArguments;
+            var b = other.TypeArguments;
+            if (ReferenceEquals(a, b))
+            {
+                return true;
+            }
+
+            if (a is null || b is null || a.Length != b.Length)
+            {
+                return false;
+            }
+
+            for (var i = 0; i < a.Length; i++)
+            {
+                if (a[i] != b[i])
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        // Per-position IsAssignableFrom: reference positions widen, value positions match exactly.
+        public static bool Matches(InstantiationKey pattern, InstantiationKey actual)
+        {
+            var p = pattern.TypeArguments;
+            var a = actual.TypeArguments;
+            if (p.Length != a.Length)
+            {
+                return false;
+            }
+
+            for (var i = 0; i < p.Length; i++)
+            {
+                if (!p[i].IsAssignableFrom(a[i]))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+        public override string ToString()
+            => $"<{string.Join(",", Array.ConvertAll(TypeArguments ?? Type.EmptyTypes, t => t.Name))}>";
+
+        public override bool Equals(object? obj)
+        {
+            return obj is InstantiationKey k && Equals(k);
+        }
+
+        public override int GetHashCode()
+        {
+            var h = 17;
+            if (TypeArguments is not null)
+            {
+                foreach (var t in TypeArguments)
+                {
+                    h = unchecked(h * 31 + (t?.GetHashCode() ?? 0));
+                }
+            }
+
+            return h;
+        }
+
+        public static bool operator ==(InstantiationKey left, InstantiationKey right)
+        {
+            return left.Equals(right);
+        }
+
+        public static bool operator !=(InstantiationKey left, InstantiationKey right)
+        {
+            return !(left == right);
+        }
+    }
+}

--- a/src/MonoMod.RuntimeDetour/Generics/MonoContextRegisterCalibrator.cs
+++ b/src/MonoMod.RuntimeDetour/Generics/MonoContextRegisterCalibrator.cs
@@ -1,0 +1,230 @@
+using MonoMod.Utils;
+using System;
+using System.Collections.Concurrent;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Mono.Cecil.Cil;
+
+namespace MonoMod.RuntimeDetour.Generics
+{
+    // Determines empirically which integer argument register Mono's JIT assigns to the dispatcher's
+    // appended generic-context parameter; TODO: is there a way to know this without having to do this hacky check?
+    //
+    // Builds a probe with the dispatcher's signature shape that returns its context parameter, then calls it through
+    // a native stub that writes a distinct magic into every integer argument register. The returned magic identifies
+    // the register; if none comes back, the context is on the stack and the capture stub can't work.
+    internal static class MonoContextRegisterCalibrator
+    {
+        private const int MagicBase = 0x4D430000;
+
+        private static readonly ConcurrentDictionary<string, int> cache = [];
+
+        // Returns the exact integer-argument-register index of the context parameter, -1 if the context is not
+        // passed in an integer register (stack), or null when calibration is unavailable for this signature/platform
+        public static int? TryFindContextArgRegister(Type[] paramTypes, int genCtxPos)
+        {
+            if (PlatformDetection.Architecture is not (ArchitectureKind.x86_64 or ArchitectureKind.Arm64))
+            {
+                return null;
+            }
+
+            var sanitized = new Type[paramTypes.Length];
+            for (var i = 0; i < paramTypes.Length; i++)
+            {
+                var t = paramTypes[i];
+                if (!t.IsValueType || t.IsByRef)
+                {
+                    sanitized[i] = typeof(IntPtr);
+                }
+                else if (StructContainsReferences(t))
+                {
+                    return null;
+                }
+                else
+                {
+                    sanitized[i] = t;
+                }
+            }
+
+            var key = CacheKey(sanitized, genCtxPos);
+            if (cache.TryGetValue(key, out var cached))
+            {
+                return cached;
+            }
+
+            try
+            {
+                var index = Calibrate(sanitized, genCtxPos);
+                cache[key] = index;
+                return index;
+            }
+            catch (Exception ex)
+            {
+                MMDbgLog.Trace($"Context-register calibration failed ({ex.GetType().Name}: {ex.Message}); using heuristic.");
+                return null;
+            }
+        }
+
+        private static int Calibrate(Type[] paramTypes, int genCtxPos)
+        {
+            using var probeDmd = new DynamicMethodDefinition("GenericContextRegisterProbe", typeof(IntPtr), paramTypes);
+            var probeIl = probeDmd.GetILProcessor();
+            probeIl.Emit(OpCodes.Ldarg, probeDmd.Definition.Parameters[genCtxPos]);
+            probeIl.Emit(OpCodes.Ret);
+            var probe = DMDCecilGenerator.Generate(probeDmd);
+            RuntimeHelpers.PrepareMethod(probe.MethodHandle);
+            var probeEntry = probe.MethodHandle.GetFunctionPointer();
+
+            var regCount = IntegerArgRegisterCount();
+            var stubCode = PlatformDetection.Architecture == ArchitectureKind.x86_64
+                ? BuildX86_64Stub(probeEntry, regCount)
+                : BuildArm64Stub(probeEntry, regCount);
+            using var stub = GenericContextCaptureStub.AllocateExecutable(stubCode);
+
+            using var callerDmd = new DynamicMethodDefinition("GenericContextRegisterCalib", typeof(IntPtr), Type.EmptyTypes);
+            var module = callerDmd.Module;
+            var il = callerDmd.GetILProcessor();
+            callerDmd.Definition.Body.InitLocals = true;
+
+            var callSite = new Mono.Cecil.CallSite(module.ImportReference(typeof(IntPtr)));
+            foreach (var t in paramTypes)
+            {
+                var local = new VariableDefinition(module.ImportReference(t));
+                callerDmd.Definition.Body.Variables.Add(local);
+                il.Emit(OpCodes.Ldloc, local);
+                callSite.Parameters.Add(new Mono.Cecil.ParameterDefinition(module.ImportReference(t)));
+            }
+            if (IntPtr.Size == 8)
+            {
+                il.Emit(OpCodes.Ldc_I8, (long)stub.BaseAddress);
+            }
+            else
+            {
+                il.Emit(OpCodes.Ldc_I4, (int)stub.BaseAddress);
+            }
+            il.Emit(OpCodes.Conv_I);
+            il.Emit(OpCodes.Calli, callSite);
+            il.Emit(OpCodes.Ret);
+
+            var caller = DMDCecilGenerator.Generate(callerDmd);
+            var result = (IntPtr)caller.Invoke(null, null)!;
+            GC.KeepAlive(probe);
+
+            var value = result.ToInt64();
+            if ((value & ~0xFFL) == MagicBase && (value & 0xFF) < regCount)
+            {
+                return (int)(value & 0xFF);
+            }
+            return -1;
+        }
+
+        private static int IntegerArgRegisterCount()
+        {
+            if (PlatformDetection.Architecture == ArchitectureKind.Arm64)
+            {
+                return 8;
+            }
+            return PlatformDetection.OS is OSKind.Windows or OSKind.Wine ? 4 : 6;
+        }
+
+        // mov <argreg_i>, MagicBase|i (for every integer arg register) ; movabs rax, probe ; jmp rax
+        private static byte[] BuildX86_64Stub(IntPtr probe, int regCount)
+        {
+            var windows = PlatformDetection.OS is OSKind.Windows or OSKind.Wine;
+            // REX.W C7 /0 (mov r/m64, imm32) prefixes per register, in arg order.
+            byte[][] movImm32 = windows
+                // Windows x64: rcx, rdx, r8, r9
+                ? [
+                    [0x48, 0xC7, 0xC1],
+                    [0x48, 0xC7, 0xC2],
+                    [0x49, 0xC7, 0xC0],
+                    [0x49, 0xC7, 0xC1],
+                ]
+                // SysV x64: rdi, rsi, rdx, rcx, r8, r9
+                : [
+                    [0x48, 0xC7, 0xC7],
+                    [0x48, 0xC7, 0xC6],
+                    [0x48, 0xC7, 0xC2],
+                    [0x48, 0xC7, 0xC1],
+                    [0x49, 0xC7, 0xC0],
+                    [0x49, 0xC7, 0xC1],
+                ];
+
+            var code = new byte[(regCount * 7) + 12];
+            var pos = 0;
+            for (var i = 0; i < regCount; i++)
+            {
+                movImm32[i].CopyTo(code, pos);
+                pos += 3;
+                BitConverter.GetBytes(MagicBase | i).CopyTo(code, pos);
+                pos += 4;
+            }
+            // movabs rax, probe
+            code[pos++] = 0x48;
+            code[pos++] = 0xB8;
+            BitConverter.GetBytes((long)probe).CopyTo(code, pos);
+            pos += 8;
+            // jmp rax
+            code[pos++] = 0xFF;
+            code[pos] = 0xE0;
+            return code;
+        }
+
+        // movz x<i>, #0x4D43, lsl #16 ; movk x<i>, #i (for x0..x7) ; ldr x16, #8 ; br x16 ; .quad probe
+        private static byte[] BuildArm64Stub(IntPtr probe, int regCount)
+        {
+            const uint MagicHigh16 = MagicBase >> 16;
+
+            var code = new byte[(regCount * 8) + 4 + 4 + 8];
+            var pos = 0;
+            for (var i = 0; i < regCount; i++)
+            {
+                // movz x<i>, #imm16, lsl #16 == 0xD2A00000 | imm16 << 5 | Rd
+                WriteUInt32(code, pos, 0xD2A00000u | (MagicHigh16 << 5) | (uint)i);
+                pos += 4;
+                // movk x<i>, #imm16 == 0xF2800000 | imm16 << 5 | Rd
+                WriteUInt32(code, pos, 0xF2800000u | ((uint)i << 5) | (uint)i);
+                pos += 4;
+            }
+            // ldr x16, #8
+            WriteUInt32(code, pos, 0x58000050u);
+            pos += 4;
+            // br x16
+            WriteUInt32(code, pos, 0xD61F0200u);
+            pos += 4;
+            BitConverter.GetBytes((long)probe).CopyTo(code, pos);
+            return code;
+        }
+
+        private static void WriteUInt32(byte[] buffer, int offset, uint value) => GenericContextCaptureStub.WriteUInt32LittleEndian(buffer, offset, value);
+
+        private static bool StructContainsReferences(Type t)
+        {
+            if (t.IsPrimitive || t.IsEnum || t.IsPointer)
+            {
+                return false;
+            }
+            foreach (var f in t.GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic))
+            {
+                var ft = f.FieldType;
+                if (!ft.IsValueType || StructContainsReferences(ft))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        private static string CacheKey(Type[] paramTypes, int genCtxPos)
+        {
+            var sb = new StringBuilder();
+            sb.Append(genCtxPos).Append(':');
+            foreach (var t in paramTypes)
+            {
+                sb.Append(t.FullName ?? t.Name).Append(';');
+            }
+            return sb.ToString();
+        }
+    }
+}

--- a/src/MonoMod.RuntimeDetour/Generics/SharedBodyDispatcher.SharedBody.cs
+++ b/src/MonoMod.RuntimeDetour/Generics/SharedBodyDispatcher.SharedBody.cs
@@ -1,0 +1,746 @@
+using MonoMod.Core;
+using MonoMod.Core.Platforms;
+using MonoMod.Utils;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+namespace MonoMod.RuntimeDetour.Generics
+{
+    internal sealed partial class SharedBodyDispatcher
+    {
+        // One per distinct shared native body pointer. Process-wide, refcounted by layers.
+        private sealed class SharedBody
+        {
+            public int BodyId { get; }
+            internal readonly IntPtr bodyPtr;
+            private readonly MethodBase openSource;
+            private readonly GenericContextReader.GenericContextKind kind;
+            private readonly ICoreNativeDetour detour;
+            private readonly object dispatchKeepAlive;
+            private readonly GenericContextCaptureStub? entryStub;
+            // MISS forward target, re-pointed to the divergent body's orig once detoured.
+            private IntPtr missEntry;
+            private readonly IntPtr detourTarget;
+            private readonly object divergentLock = new();
+            // Divergent concrete bodies detoured, mapped to their detour; reference instantiations share one.
+            private readonly Dictionary<IntPtr, ICoreNativeDetour> divergentBodyDetours = [];
+            private readonly HashSet<IntPtr> detouredAddrs = [];
+            // Tier-up re-detours, additive over _detour.
+            private readonly List<PlatformTriple.NativeDetour> retierDetours = [];
+            private readonly ConcurrentDictionary<InstantiationKey, ICoreNativeDetour> divergentDetours = [];
+            private readonly bool dropsCtx;
+            // Mono gsharedvt: the context is unrecoverable and reading it can abort the runtime,
+            // so dispatch by the single registered instantiation (each value instantiation has its own detoured body).
+            private readonly bool isValueTypeShared;
+            private readonly ConcurrentDictionary<InstantiationKey, (IntPtr Entry, object KeepAlive)> origClones = [];
+
+            private readonly ConcurrentDictionary<InstantiationKey, KeyChain> entries = [];
+            // Registered instantiation's runtime pointer (MethodTable*/MethodDesc*) -> key; the generic context is that pointer,
+            // so resolution is a pointer comparison, avoiding handle->Type conversions that fault on .NET 5/6.
+            private readonly ConcurrentDictionary<IntPtr, InstantiationKey> contextPtrToKey = [];
+            private readonly ConcurrentDictionary<SharedBodyDispatcher, byte> owners = [];
+            private readonly ConcurrentBag<(GCHandle Handle, object? KeepAlive)> retired = [];
+
+            private readonly object _lock = new();
+            private int layerCount;
+            private bool disposed;
+
+            private bool UseContextPointerMatch
+                => PlatformDetection.Runtime != RuntimeKind.Mono
+                   && kind is GenericContextReader.GenericContextKind.MethodTable or GenericContextReader.GenericContextKind.MethodDesc;
+
+            private bool TryGetIdentityPointer(MethodBase closedSource, out IntPtr ptr)
+            {
+                ptr = IntPtr.Zero;
+                try
+                {
+                    switch (kind)
+                    {
+                        case GenericContextReader.GenericContextKind.MethodTable:
+                            if (closedSource.DeclaringType is { } dt)
+                            {
+                                ptr = dt.TypeHandle.Value;
+                                return true;
+                            }
+                            return false;
+                        case GenericContextReader.GenericContextKind.MethodDesc:
+                            ptr = closedSource.MethodHandle.Value;
+                            return true;
+                        default:
+                            return false;
+                    }
+                }
+                catch
+                {
+                    return false;
+                }
+            }
+
+            // Real JITed code address when the detoured body is a stub/precode in front of it;
+            // with-orig calls it directly to avoid the stub's looping alt-entry.
+            private readonly IntPtr realBody;
+            private readonly string? canonKey;
+            private readonly IntPtr registrationKey;
+
+            private SharedBody(int bodyId, IntPtr bodyPtr, IntPtr registrationKey, MethodBase openSource, GenericContextReader.GenericContextKind kind,
+                ICoreNativeDetour detour, object dispatchKeepAlive, GenericContextCaptureStub? entryStub, IntPtr missEntry, bool dropsCtx,
+                IntPtr detourTarget, bool isValueTypeShared, IntPtr realBody, string? canonKey)
+            {
+                BodyId = bodyId;
+                this.bodyPtr = bodyPtr;
+                this.registrationKey = registrationKey;
+                this.openSource = openSource;
+                this.kind = kind;
+                this.detour = detour;
+                this.dispatchKeepAlive = dispatchKeepAlive;
+                this.entryStub = entryStub;
+                this.missEntry = missEntry;
+                this.dropsCtx = dropsCtx;
+                this.detourTarget = detourTarget;
+                this.isValueTypeShared = isValueTypeShared;
+                this.realBody = realBody;
+                this.canonKey = canonKey;
+                detouredAddrs.Add(bodyPtr);
+                if (registrationKey != IntPtr.Zero)
+                {
+                    detouredAddrs.Add(registrationKey);
+                }
+                if (realBody != IntPtr.Zero)
+                {
+                    detouredAddrs.Add(realBody);
+                }
+            }
+
+            private static bool ContainsValueTypeArg(MethodBase closedSource)
+            {
+                if (closedSource.DeclaringType is { IsGenericType: true } dt)
+                {
+                    foreach (var a in dt.GetGenericArguments())
+                    {
+                        if (a.IsValueType)
+                        {
+                            return true;
+                        }
+                    }
+                }
+                if (closedSource.IsGenericMethod)
+                {
+                    foreach (var a in closedSource.GetGenericArguments())
+                    {
+                        if (a.IsValueType)
+                        {
+                            return true;
+                        }
+                    }
+                }
+                return false;
+            }
+
+            private static bool KeyHasValueTypeArg(InstantiationKey key)
+            {
+                foreach (var t in key.TypeArguments)
+                {
+                    if (t.IsValueType)
+                    {
+                        return true;
+                    }
+                }
+                return false;
+            }
+
+            public static SharedBody Create(IntPtr bodyPtr, MethodBase closedSource, MethodBase openSource, GenericContextReader.GenericContextKind kind, IntPtr realBody, string? canonKey)
+            {
+                var bodyId = Interlocked.Increment(ref nextBodyId);
+                var dispatcher = UniversalDispatcher.Build(closedSource, kind, bodyId);
+
+                // Mono passes the context in a dedicated register for everything but ThisObject;
+                // bridge it with a native capture stub. Elsewhere the body is detoured straight to the managed dispatcher.
+                var dropsCtx = PlatformDetection.Runtime == RuntimeKind.Mono && kind != GenericContextReader.GenericContextKind.ThisObject;
+                GenericContextCaptureStub? entryStub = null;
+                IntPtr detourTarget;
+                if (dropsCtx)
+                {
+                    entryStub = new GenericContextCaptureStub(dispatcher.Entry, dispatcher.ContextArgRegisterIndex);
+                    detourTarget = entryStub.Address;
+                }
+                else
+                {
+                    detourTarget = dispatcher.Entry;
+                }
+
+                var isValueTypeShared = dropsCtx && ContainsValueTypeArg(closedSource);
+
+                // Detour the real JITed shared code (compile-hook codeStart) when the walked body is a stub/precode in front of it. 
+                var haveReal = realBody != IntPtr.Zero && realBody != bodyPtr;
+                var detourFrom = haveReal ? realBody : bodyPtr;
+                ICoreNativeDetour detour;
+                var detouredBody = detourFrom;
+                // orig calls the real code directly only when a (non-precode) stub was detoured, whose alt-entry would loop;
+                // when the real code itself was detoured, orig uses the detour's own alt-entry.
+                var origRealBody = detourFrom == realBody ? IntPtr.Zero : realBody;
+                try
+                {
+                    detour = DetourFactory.Current.CreateNativeDetour(detourFrom, detourTarget);
+                }
+                catch (InvalidOperationException) when (realBody != IntPtr.Zero && realBody != detourFrom)
+                {
+                    detour = DetourFactory.Current.CreateNativeDetour(realBody, detourTarget);
+                    detouredBody = realBody;
+                    origRealBody = IntPtr.Zero;
+                }
+                // Mono uses a per-instantiation clone instead (the original body needs the context register),
+                // so _missEntry is unused there. When a stub distinct from the real code was detoured,
+                // forward to the real code directly, else the detour's own alt-entry.
+                var missEntry = dropsCtx ? IntPtr.Zero : (origRealBody != IntPtr.Zero ? origRealBody : detour.OrigEntrypoint);
+                return new SharedBody(bodyId, detouredBody, bodyPtr, openSource, kind, detour, dispatcher.KeepAlive, entryStub, missEntry, dropsCtx, detourTarget, isValueTypeShared, origRealBody, canonKey);
+            }
+
+            public void AddOwner(SharedBodyDispatcher d) => owners.TryAdd(d, 0);
+            public void RemoveOwner(SharedBodyDispatcher d) => owners.TryRemove(d, out _);
+
+            public IDisposable AddLayer(InstantiationKey key, MethodBase closedSource, MethodInfo closedTarget, bool wantsOrig)
+            {
+                lock (_lock)
+                {
+                    var chain = entries.GetOrAdd(key, k => new KeyChain(this, k, closedSource));
+
+                    if (UseContextPointerMatch && TryGetIdentityPointer(closedSource, out var idPtr) && idPtr != IntPtr.Zero)
+                    {
+                        contextPtrToKey[idPtr] = key;
+                    }
+
+                    EnsureDivergentBodyDetoured(key, closedSource);
+
+                    var layer = chain.AddLayer(closedTarget, wantsOrig);
+                    layerCount += 1;
+                    WatchInstantiation(closedSource, this);
+                    return new LayerHandle(this, chain, layer);
+                }
+            }
+
+            // Fires when a body for a watched open generic method is JIT-compiled, before it runs.
+            internal void TryDetourCompiledInstantiation(MethodBase compiled, Type[] methodArgs, IntPtr codeStart, IntPtr codeStartRw, ulong codeSize)
+            {
+                if (disposed || codeStart == IntPtr.Zero || dropsCtx)
+                {
+                    return;
+                }
+
+                // Tiered compilation recompiled the shared __Canon body at a new address; re-detour it.
+                if (PlatformDetection.Runtime == RuntimeKind.CoreCLR && canonKey is not null
+                    && IsCanonicalInstantiation(compiled) && CanonKey(compiled) == canonKey)
+                {
+                    OnBodyRecompiled(codeStart, codeStartRw, codeSize);
+                    return;
+                }
+
+                if (codeStart == bodyPtr)
+                {
+                    return;
+                }
+
+                var declArgs = compiled.DeclaringType is { IsGenericType: true } dt ? dt.GetGenericArguments() : Type.EmptyTypes;
+                Type[] full = declArgs.Length == 0 ? methodArgs : [.. declArgs, .. methodArgs];
+                var key = new InstantiationKey(full);
+
+                if (!entries.ContainsKey(key))
+                {
+                    return;
+                }
+
+                // Only detour bodies that carry a generic context (same ABI as __Canon);
+                // an unshared value-type body has no context arg and routing it would misalign the ABI.
+                bool hasCtx;
+                try
+                {
+                    hasCtx = PlatformTriple.Current.Runtime.RequiresGenericContext(compiled);
+                }
+                catch
+                {
+                    hasCtx = false;
+                }
+                if (!hasCtx)
+                {
+                    return;
+                }
+
+                lock (divergentLock)
+                {
+                    MapDivergentDetour(key, codeStart);
+                }
+            }
+
+            // Build orig as a direct call into the original shared body with this instantiation's fixed generic
+            // context, instead of cloning the concrete method's IL. Only needed on .NET Core (RequiresBodyThunkWalking),
+            // where cloning the concrete instantiation makes the runtime route the call around the canonical detour
+            // (and crashes on 3.x). Elsewhere the clone (EnsureBaseClone) is used.
+            internal bool TryBuildOrigViaBody(MethodBase closedSource, InstantiationKey key, Type origDelType, out Delegate orig, out object? keepAlive)
+            {
+                orig = null!;
+                keepAlive = null;
+                if (PlatformDetection.Runtime != RuntimeKind.CoreCLR
+                    || dropsCtx
+                    || kind == GenericContextReader.GenericContextKind.ThisObject
+                    || !PlatformTriple.Current.SupportedFeatures.Has(Core.Platforms.RuntimeFeature.RequiresBodyThunkWalking))
+                {
+                    return false;
+                }
+                if (!TryGetIdentityPointer(closedSource, out var ctx) || ctx == IntPtr.Zero)
+                {
+                    return false;
+                }
+                // If this instantiation runs on its own detoured divergent body, orig must skip that detour and call
+                // the concrete body's OrigEntrypoint, or it recurses.
+                var origEntry = detour.OrigEntrypoint;
+                if (divergentDetours.TryGetValue(key, out var divergent) && divergent.OrigEntrypoint != IntPtr.Zero)
+                {
+                    origEntry = divergent.OrigEntrypoint;
+                }
+                else
+                {
+                    // The detoured body may be a stub/precode whose alt-entry loops; call the real JITed code
+                    // directly, falling back to a fresh lookup for a body created by an earlier hook.
+
+                    var rBody = realBody != IntPtr.Zero ? realBody : GetRecordedCanonRealBody(openSource, closedSource);
+                    if (rBody != IntPtr.Zero && rBody != bodyPtr)
+                    {
+                        origEntry = rBody;
+                    }
+                }
+                if (origEntry == IntPtr.Zero)
+                {
+                    return false;
+                }
+                try
+                {
+                    (orig, keepAlive) = UniversalDispatcher.BuildOrigViaBody(closedSource, origEntry, ctx, origDelType);
+                    return true;
+                }
+                catch (Exception ex)
+                {
+                    MMDbgLog.Warning($"Orig-via-body failed for {closedSource}, falling back to clone: {ex}");
+                    orig = null!;
+                    keepAlive = null;
+                    return false;
+                }
+            }
+
+            // .NET Core instance/virtual generic methods (and static mixed <ref,value> keys) run on their own
+            // divergent body instead of the detoured __Canon body, bypassing the canon detour. Follow the concrete
+            // instantiation's instantiating stub to that body and detour it to the same dispatcher.
+            private void EnsureDivergentBodyDetoured(InstantiationKey key, MethodBase closedSource)
+            {
+                if (PlatformDetection.Runtime != RuntimeKind.CoreCLR || dropsCtx)
+                {
+                    return;
+                }
+
+                // Force-materialise so the no-reload walk can follow the instantiating stub.
+                // On .NET Core 3.x, compiling a shared generic instantiation access-violates once its body is
+                // detoured, so skip there and let the JIT compile hook catch the divergent body instead.
+                if (PlatformDetection.RuntimeVersion.Major != 3)
+                {
+                    try
+                    {
+                        PlatformTriple.Current.Compile(closedSource);
+                    }
+                    catch (Exception ex)
+                    {
+                        MMDbgLog.Trace($"Divergent-body force-compile failed for {closedSource}: {ex.GetType().Name}: {ex.Message}");
+                    }
+                }
+
+                IntPtr concrete;
+                bool followed;
+                try
+                {
+                    concrete = PlatformTriple.Current.GetSharedGenericBodyNoReload(closedSource, out followed);
+                }
+                catch (Exception ex)
+                {
+                    MMDbgLog.Trace($"Divergent-body resolve failed for {closedSource}: {ex.GetType().Name}: {ex.Message}");
+                    return;
+                }
+
+                if (!followed || concrete == IntPtr.Zero || concrete == bodyPtr)
+                {
+                    return;
+                }
+
+                lock (divergentLock)
+                {
+                    MapDivergentDetour(key, concrete);
+                }
+            }
+
+            // The shared __Canon body was re-JITed at `newCodeStart`;
+            // reference instantiations now route there, bypassing the original detour.
+            // Add a detour on the new code to the same dispatcher;
+            // the original _detour stays applied for stragglers on the old code.
+            // Writes through the writable alias `newCodeStartRw` since W^X JIT code (e.g. Apple-Silicon arm64) is execute-only
+            // and patching the exec address corrupts it.
+            private void OnBodyRecompiled(IntPtr newCodeStart, IntPtr newCodeStartRw, ulong codeSize)
+            {
+                lock (divergentLock)
+                {
+                    if (disposed || newCodeStart == IntPtr.Zero)
+                    {
+                        return;
+                    }
+                    if (!detouredAddrs.Add(newCodeStart))
+                    {
+                        return;
+                    }
+                    PlatformTriple.NativeDetour nd;
+                    try
+                    {
+                        nd = PlatformTriple.Current.CreateNativeDetour(newCodeStart, detourTarget, (int)codeSize, newCodeStartRw);
+                    }
+                    catch (Exception ex)
+                    {
+                        detouredAddrs.Remove(newCodeStart);
+                        MMDbgLog.Warning($"Failed to re-detour recompiled body 0x{newCodeStart:x16}: {ex.GetType().Name}");
+                        return;
+                    }
+                    retierDetours.Add(nd);
+                    if (nd.HasAltEntry && divergentBodyDetours.Count == 0)
+                    {
+                        missEntry = nd.AltEntry;
+                    }
+                    MMDbgLog.Trace($"{openSource} __Canon body recompiled => re-detour 0x{newCodeStart:x16} => 0x{detourTarget:x16}");
+                }
+            }
+
+            private void MapDivergentDetour(InstantiationKey key, IntPtr concrete)
+            {
+                if (disposed)
+                {
+                    return;
+                }
+                if (divergentBodyDetours.TryGetValue(concrete, out var existing))
+                {
+                    divergentDetours[key] = existing;
+                    return;
+                }
+                try
+                {
+                    var d = DetourFactory.Current.CreateNativeDetour(concrete, detourTarget);
+                    divergentBodyDetours[concrete] = d;
+                    divergentDetours[key] = d;
+                    if (d.OrigEntrypoint != IntPtr.Zero)
+                    {
+                        missEntry = d.OrigEntrypoint;
+                    }
+                    MMDbgLog.Trace($"{openSource} {key} divergent body 0x{concrete:x16} => 0x{detourTarget:x16}");
+                }
+                catch (Exception ex)
+                {
+                    MMDbgLog.Warning($"Failed to detour divergent body 0x{concrete:x16}: {ex}");
+                }
+            }
+
+            private void RemoveLayer(KeyChain chain, KeyChain.Layer layer)
+            {
+                lock (_lock)
+                {
+                    if (disposed)
+                    {
+                        return;
+                    }
+
+                    var emptied = chain.RemoveLayer(layer);
+                    if (emptied)
+                    {
+                        UnwatchInstantiation(chain.ClosedSource, this);
+                        entries.TryRemove(chain.Key, out _);
+                        chain.Dispose();
+                    }
+
+                    layerCount -= 1;
+                    if (layerCount == 0)
+                    {
+                        Teardown();
+                    }
+                }
+            }
+
+            // Non-ThisObject: context is a raw MethodTable*/MethodDesc* (CoreCLR/Framework arg, or Mono RGCTX reg).
+            public IntPtr Resolve(IntPtr contextPtr)
+            {
+                // Mono gsharedvt: Reading the context faults.
+                if (isValueTypeShared)
+                {
+                    return TryGetSingleActiveEntry(out var entry) ? entry : IntPtr.Zero;
+                }
+
+                if (inResolve)
+                {
+                    return MissEntry(contextPtr);
+                }
+
+                inResolve = true;
+                try
+                {
+                    // Safe fast path: match the context pointer against the registered instantiations by pointer.
+                    // sidestepping problematic handle->Type/Method conversions on .NET 5/6.
+                    if (UseContextPointerMatch && contextPtrToKey.TryGetValue(contextPtr, out var matchedKey))
+                    {
+                        return ResolveCore(matchedKey.TypeArguments);
+                    }
+
+                    return ResolveCore(GenericContextReader.Read(contextPtr, kind, openSource));
+                }
+                catch (Exception ex)
+                {
+                    // Mono gsharedvt whose read threw: each value-type instantiation has its own body,
+                    // so with exactly one active instantiation the dispatch is unambiguous.
+                    if (dropsCtx && TryGetSingleActiveEntry(out var soleEntry))
+                    {
+                        return soleEntry;
+                    }
+                    MMDbgLog.Warning($"Exception in generic dispatch resolve:\n{ex}");
+                }
+                finally
+                {
+                    inResolve = false;
+                }
+
+                return MissEntry(contextPtr);
+            }
+
+            // Returns the single active (non-zero) per-key entry if this body has exactly one, else false.
+            private bool TryGetSingleActiveEntry(out IntPtr entry)
+            {
+                entry = IntPtr.Zero;
+                var count = 0;
+                foreach (var chain in entries.Values)
+                {
+                    if (chain.Entry == IntPtr.Zero)
+                    {
+                        continue;
+                    }
+                    if (++count > 1)
+                    {
+                        return false;
+                    }
+                    entry = chain.Entry;
+                }
+                return count == 1;
+            }
+
+            // Where to forward when no hook matches. Prefer the original body via its native OrigEntrypoint;
+            // fall back to a concrete per-instantiation clone when there is no native entry to forward to
+            // (Mono non-ThisObject, or no alt-entry factory)
+            private IntPtr MissEntry(IntPtr contextPtr)
+            {
+                if (!dropsCtx && missEntry != IntPtr.Zero)
+                {
+                    return missEntry;
+                }
+                try
+                {
+                    var typeArgs = GenericContextReader.Read(contextPtr, kind, openSource);
+                    return GetOrBuildOrigClone(new InstantiationKey(typeArgs), typeArgs);
+                }
+                catch (Exception ex)
+                {
+                    MMDbgLog.Warning($"Failed to build orig clone:\n{ex}");
+                    return IntPtr.Zero;
+                }
+            }
+
+            private IntPtr MissEntry(InstantiationKey key, Type[] typeArgs) => (dropsCtx || missEntry == IntPtr.Zero) ? GetOrBuildOrigClone(key, typeArgs) : missEntry;
+
+            private IntPtr GetOrBuildOrigClone(InstantiationKey key, Type[] typeArgs)
+            {
+                if (origClones.TryGetValue(key, out var existing))
+                {
+                    return existing.Entry;
+                }
+
+                var closedSource = GenericInstantiator.CloseSource(openSource, typeArgs);
+                using var dmd = new DynamicMethodDefinition(closedSource);
+                var clone = DMDCecilGenerator.Generate(dmd);
+                RuntimeHelpers.PrepareMethod(clone.MethodHandle);
+
+                var ctxIsForwarded = GenericHelper.IsContextForwarded(kind);
+
+                IntPtr entry;
+                object keepAlive;
+                if (ctxIsForwarded)
+                {
+                    var tramp = SharedDispatchTrampoline.Build(closedSource, clone, null, kind);
+                    entry = tramp.Entry;
+                    object[] keep = [tramp.KeepAlive, clone];
+                    keepAlive = keep;
+                }
+                else
+                {
+                    entry = clone.MethodHandle.GetFunctionPointer();
+                    keepAlive = clone;
+                }
+
+                return origClones.GetOrAdd(key, (entry, keepAlive)).Entry;
+            }
+
+            public IntPtr ResolveFromThisObject(object self)
+            {
+                if (inResolve)
+                {
+                    return missEntry;
+                }
+
+                inResolve = true;
+                try
+                {
+                    return ResolveCore(GenericContextReader.FromThisObject(self, openSource));
+                }
+                catch (Exception ex)
+                {
+                    MMDbgLog.Warning($"Exception in generic dispatch resolve:\n{ex}");
+                }
+                finally
+                {
+                    inResolve = false;
+                }
+
+                return missEntry;
+            }
+
+            private IntPtr ResolveCore(Type[] typeArgs)
+            {
+                var key = new InstantiationKey(typeArgs);
+
+                if (entries.TryGetValue(key, out var chain) && chain.Entry != IntPtr.Zero)
+                {
+                    return chain.Entry;
+                }
+
+                var primed = false;
+                // Auto-discovery varies reference positions and holds value positions fixed
+                // every key reaching one shared body shares its value signature by construction.
+                // Value-containing keys are gated off only on Mono (unreadable gsharedvt context).
+                var valueKeyGatedOff = KeyHasValueTypeArg(key) && !GenericHook.SupportsValueTypeAutoPrime;
+                if (!valueKeyGatedOff)
+                {
+                    foreach (var kv in owners)
+                    {
+                        var owner = kv.Key;
+                        if (owner.AutoPrime == AutoPrimeMode.All)
+                        {
+                            owner.OwnerHook.OnDiscovered(key);
+                            primed = true;
+                        }
+                        else if (owner.AutoPrime == AutoPrimeMode.Compatible)
+                        {
+                            foreach (var p in owner.OwnerHook.Primed)
+                            {
+                                // Value arg matches exactly; reference arg IsAssignableFrom
+                                if (InstantiationKey.Matches(p.Key, key))
+                                {
+                                    owner.OwnerHook.OnDiscovered(key);
+                                    primed = true;
+                                }
+                            }
+                        }
+                    }
+                }
+
+                if (primed && entries.TryGetValue(key, out chain) && chain.Entry != IntPtr.Zero)
+                {
+                    return chain.Entry;
+                }
+
+                return MissEntry(key, typeArgs);
+            }
+
+            internal void Retire(GCHandle handle, object? keepAlive) => retired.Add((handle, keepAlive));
+
+            internal SharedDispatchTrampoline.Result BuildTop(MethodBase closedSource, MethodInfo closedTarget, Delegate? orig) => BuildTopEntry(closedSource, closedTarget, orig, kind);
+
+            private void Teardown()
+            {
+                if (disposed)
+                {
+                    return;
+                }
+                disposed = true;
+
+                lock (bodyLock)
+                {
+                    bodiesByPtr.TryRemove(registrationKey, out _);
+                    bodiesById.TryRemove(BodyId, out _);
+                }
+                if (canonKey is not null)
+                {
+                    canonResolution.TryRemove(canonKey, out _);
+                }
+
+                detour.Dispose();
+                lock (divergentLock)
+                {
+                    foreach (var d in divergentBodyDetours.Values)
+                    {
+                        d.Dispose();
+                    }
+                    divergentBodyDetours.Clear();
+                    divergentDetours.Clear();
+                    foreach (var nd in retierDetours)
+                    {
+                        nd.Simple.Dispose();
+                        nd.AltHandle?.Dispose();
+                    }
+                    retierDetours.Clear();
+                }
+                entryStub?.Dispose();
+                GC.KeepAlive(dispatchKeepAlive);
+                origClones.Clear();
+
+                foreach (var chain in entries.Values)
+                {
+                    UnwatchInstantiation(chain.ClosedSource, this);
+                    chain.Dispose();
+                }
+                entries.Clear();
+
+                foreach (var (handle, _) in retired)
+                {
+                    if (handle.IsAllocated)
+                    {
+                        handle.Free();
+                    }
+                }
+            }
+
+            private sealed class LayerHandle : IDisposable
+            {
+                private readonly SharedBody body;
+                private readonly KeyChain chain;
+                private readonly KeyChain.Layer layer;
+                private bool done;
+
+                public LayerHandle(SharedBody body, KeyChain chain, KeyChain.Layer layer)
+                {
+                    this.body = body;
+                    this.chain = chain;
+                    this.layer = layer;
+                }
+
+                public void Dispose()
+                {
+                    if (done)
+                    {
+                        return;
+                    }
+                    done = true;
+                    body.RemoveLayer(chain, layer);
+                }
+            }
+        }
+    }
+}

--- a/src/MonoMod.RuntimeDetour/Generics/SharedBodyDispatcher.cs
+++ b/src/MonoMod.RuntimeDetour/Generics/SharedBodyDispatcher.cs
@@ -1,0 +1,623 @@
+using MonoMod.Core.Platforms;
+using MonoMod.Utils;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+namespace MonoMod.RuntimeDetour.Generics
+{
+    /// <summary>
+    /// Owns the shared native dispatch for one open generic source. The native shared body is process-global (one
+    /// native detour per distinct body pointer, refcounted by live layers), so multiple <see cref="GenericHook"/>s
+    /// over the same closed instantiation stack into a single per-key chain.
+    /// Each instance (one per <see cref="GenericHook"/>) owns a set of layers and removes exactly those on dispose.
+    /// </summary>
+    internal sealed partial class SharedBodyDispatcher : IDisposable
+    {
+        private static readonly ConcurrentDictionary<IntPtr, SharedBody> bodiesByPtr = [];
+        private static readonly ConcurrentDictionary<int, SharedBody> bodiesById = [];
+        private static int nextBodyId;
+        private static readonly object bodyLock = new();
+
+        // Watched open generic-method definitions -> the SharedBodies handling their instantiations. On .NET Core an
+        // instance/virtual instantiation runs on its own divergent body, compiled lazily on the first (bypassing)
+        // call; the compile hook matches it by type arguments and detours it.
+        private static readonly ConcurrentDictionary<MethodBase, ConcurrentDictionary<SharedBody, byte>> watchByOpenDef = [];
+        private static int compileHookSubscribed;
+
+        private static MethodBase? OpenDefOf(MethodBase m)
+        {
+            try
+            {
+                return m is MethodInfo mi && m.IsGenericMethod && !m.IsGenericMethodDefinition ? mi.GetGenericMethodDefinition() : null;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        // Null on runtimes without __Canon (Mono).
+        private static readonly Type? canonType = typeof(object).Assembly.GetType("System.__Canon");
+
+        private static bool IsCanonicalInstantiation(MethodBase m)
+        {
+            if (canonType is null)
+            {
+                return false;
+            }
+            try
+            {
+                if (m.IsGenericMethod && !m.IsGenericMethodDefinition && Array.IndexOf(m.GetGenericArguments(), canonType) >= 0)
+                {
+                    return true;
+                }
+                return m.DeclaringType is { IsGenericType: true, ContainsGenericParameters: false } dt
+                    && Array.IndexOf(dt.GetGenericArguments(), canonType) >= 0;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        private static void EnsureCompileHookSubscribed()
+        {
+            if (Interlocked.CompareExchange(ref compileHookSubscribed, 1, 0) != 0)
+            {
+                return;
+            }
+            var triple = PlatformTriple.Current;
+            if (triple.SupportedFeatures.Has(Core.Platforms.RuntimeFeature.CompileMethodHook))
+            {
+                triple.Runtime.OnMethodCompiled += OnAnyMethodCompiled;
+            }
+        }
+
+        private static void OnAnyMethodCompiled(RuntimeMethodHandle methodHandle, MethodBase? method, IntPtr codeStart, IntPtr codeStartRw, ulong codeSize)
+        {
+            if (method is null)
+            {
+                return;
+            }
+            if (codeStart != IntPtr.Zero && IsCanonicalInstantiation(method))
+            {
+                try
+                {
+                    var ck = CanonKey(method);
+                    if (ck is not null)
+                    {
+                        canonRealBody[ck] = codeStart;
+                    }
+                }
+                catch { }
+            }
+            if (watchByOpenDef.IsEmpty)
+            {
+                return;
+            }
+            try
+            {
+                var openDef = OpenDefOf(method);
+                if (openDef is null || !watchByOpenDef.TryGetValue(openDef, out var bodies))
+                {
+                    return;
+                }
+                var methodArgs = method.GetGenericArguments();
+                foreach (var kv in bodies)
+                {
+                    kv.Key.TryDetourCompiledInstantiation(method, methodArgs, codeStart, codeStartRw, codeSize);
+                }
+            }
+            catch { }
+        }
+
+        private static void WatchInstantiation(MethodBase closedSource, SharedBody body)
+        {
+            var openDef = OpenDefOf(closedSource);
+            if (openDef is null)
+            {
+                return;
+            }
+
+            // Only available where the runtime exposes CompileMethodHook;
+            // Mono has none, so an instantiation there is reached only via its canonical detour or explicit priming.
+            if (!PlatformTriple.Current.SupportedFeatures.Has(Core.Platforms.RuntimeFeature.CompileMethodHook))
+            {
+                return;
+            }
+            EnsureCompileHookSubscribed();
+
+            var set = watchByOpenDef.GetOrAdd(openDef, static _ => []);
+            set[body] = 0;
+        }
+
+        private static void UnwatchInstantiation(MethodBase closedSource, SharedBody body)
+        {
+            var openDef = OpenDefOf(closedSource);
+            if (openDef is null)
+            {
+                return;
+            }
+            if (watchByOpenDef.TryGetValue(openDef, out var set))
+            {
+                set.TryRemove(body, out _);
+                if (set.IsEmpty)
+                {
+                    watchByOpenDef.TryRemove(openDef, out _);
+                }
+            }
+        }
+
+        private readonly MethodBase openSource;
+        private readonly GenericContextReader.GenericContextKind _kind;
+
+        internal AutoPrimeMode AutoPrime { get; }
+        internal GenericHook OwnerHook { get; }
+
+        [ThreadStatic]
+        private static bool inResolve;
+
+        private readonly Dictionary<InstantiationKey, (SharedBody Body, IDisposable Layer)> owned = [];
+        private readonly HashSet<SharedBody> touchedBodies = [];
+        private readonly object _lock = new();
+        private bool disposed;
+
+        public SharedBodyDispatcher(MethodBase openSource, AutoPrimeMode autoPrime, GenericHook owner)
+        {
+            this.openSource = openSource;
+            _kind = GenericContextReader.ClassifyContext(openSource);
+            AutoPrime = autoPrime;
+            OwnerHook = owner;
+            EnsureCompileHookSubscribed();
+        }
+
+        public bool Contains(InstantiationKey key)
+        {
+            lock (_lock)
+            {
+                return owned.ContainsKey(key);
+            }
+        }
+
+        public void Register(InstantiationKey key, MethodBase closedSource, MethodInfo closedTarget, bool wantsOrig)
+        {
+            Helpers.ThrowIfArgumentNull(closedSource);
+            Helpers.ThrowIfArgumentNull(closedTarget);
+
+            if (RequiresUnportedMonoCaptureStub)
+            {
+                throw new PlatformNotSupportedException($"Generic hooking is not supported here: {PlatformDetection.OS}, {PlatformDetection.Runtime}, {PlatformDetection.Architecture}");
+            }
+
+            Compile(closedTarget);
+
+            lock (_lock)
+            {
+                if (disposed)
+                {
+                    throw new ObjectDisposedException(nameof(SharedBodyDispatcher));
+                }
+
+                if (owned.ContainsKey(key))
+                {
+                    return;
+                }
+
+                var body = AcquireBody(closedSource);
+                body.AddOwner(this);
+                touchedBodies.Add(body);
+
+                var layer = body.AddLayer(key, closedSource, closedTarget, wantsOrig);
+                owned[key] = (body, layer);
+            }
+        }
+
+        public void Dispose()
+        {
+            lock (_lock)
+            {
+                if (disposed)
+                {
+                    return;
+                }
+
+                disposed = true;
+
+                foreach (var t in owned.Values)
+                {
+                    t.Layer.Dispose();
+                }
+                owned.Clear();
+
+                foreach (var body in touchedBodies)
+                {
+                    body.RemoveOwner(this);
+                }
+                touchedBodies.Clear();
+            }
+        }
+
+        private SharedBody AcquireBody(MethodBase closedSource)
+        {
+            var (bodyPtr, realBody, canonKey) = ResolveBodyPtr(closedSource);
+
+            if (bodiesByPtr.TryGetValue(bodyPtr, out var existing))
+            {
+                return existing;
+            }
+
+            lock (bodyLock)
+            {
+                if (bodiesByPtr.TryGetValue(bodyPtr, out existing))
+                {
+                    return existing;
+                }
+
+                var body = SharedBody.Create(bodyPtr, closedSource, openSource, _kind, realBody, canonKey);
+                bodiesByPtr[bodyPtr] = body;
+                bodiesById[body.BodyId] = body;
+                return body;
+            }
+        }
+
+        // Resolves the shared native body for a closed instantiation, preferring the canonical (__Canon-filled) instantiation
+        private (IntPtr Body, IntPtr RealBody, string? CanonKey) ResolveBodyPtr(MethodBase closedSource)
+        {
+            var canonical = TryGetCanonicalSource(openSource, closedSource);
+            string? canonKey = null;
+            if (canonical is not null)
+            {
+                // Resolve each canon once and reuse for siblings: re-compiling an already-JITed shared instantiation
+                // crashes natively on .NET Core 3.x once its body is detoured.
+                canonKey = CanonKey(canonical);
+                if (canonKey is not null && canonResolution.TryGetValue(canonKey, out var cachedBody))
+                {
+                    var cachedReal = canonRealBody.TryGetValue(canonKey, out var cr) && cr != cachedBody ? cr : IntPtr.Zero;
+                    return (cachedBody, cachedReal, canonKey);
+                }
+
+                try
+                {
+                    Compile(canonical);
+                    var body = PlatformTriple.Current.GetNativeMethodBody(canonical);
+                    var realBody = canonKey is not null && canonRealBody.TryGetValue(canonKey, out var rb) && rb != body ? rb : IntPtr.Zero;
+                    if (canonKey is not null)
+                    {
+                        canonResolution[canonKey] = body;
+                    }
+                    return (body, realBody, canonKey);
+                }
+                catch (Exception ex)
+                {
+                    MMDbgLog.Trace($"Canonical shared-body resolution failed for {closedSource}; using concrete instantiation. {ex.GetType().Name}: {ex.Message}");
+                }
+            }
+
+            Compile(closedSource);
+            return (PlatformTriple.Current.GetNativeMethodBody(closedSource), IntPtr.Zero, canonKey);
+        }
+
+        // Canon identity -> resolved shared body ptr.
+        private static readonly ConcurrentDictionary<string, IntPtr> canonResolution = [];
+
+        // Canon identity -> real JITed code address, recorded by OnAnyMethodCompiled.
+        private static readonly ConcurrentDictionary<string, IntPtr> canonRealBody = [];
+
+        // A stable, allocation-only identity for a canonical shared instantiation (no native handle access).
+        private static string? CanonKey(MethodBase canonical)
+        {
+            try
+            {
+                var dt = canonical.DeclaringType;
+                var dtKey = dt is null ? "" : (dt.AssemblyQualifiedName ?? dt.FullName ?? dt.Name);
+                return dtKey + "|" + canonical.ToString();
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        // The recorded real code-start for the canon of closedSource, or zero.
+        private static IntPtr GetRecordedCanonRealBody(MethodBase openSource, MethodBase closedSource)
+        {
+            try
+            {
+                var canonical = TryGetCanonicalSource(openSource, closedSource);
+                if (canonical is null)
+                {
+                    return IntPtr.Zero;
+                }
+                var ck = CanonKey(canonical);
+                return (ck is not null && canonRealBody.TryGetValue(ck, out var rb)) ? rb : IntPtr.Zero;
+            }
+            catch
+            {
+                return IntPtr.Zero;
+            }
+        }
+
+        // The canonical instantiation whose native code is the shared body, or null when canonicalization doesn't
+        // apply. Only CoreCLR routes shared instantiations through instantiating stubs the walk must skip
+        // Mono and .NET Framework stay on the existing path.
+        private static MethodBase? TryGetCanonicalSource(MethodBase openSource, MethodBase closedSource)
+        {
+            if (PlatformDetection.Runtime != RuntimeKind.CoreCLR
+                || !GenericHelper.MethodIsShared(closedSource)
+                || canonType is not { } canon)
+            {
+                return null;
+            }
+
+            try
+            {
+                var dt = closedSource.DeclaringType;
+                var declArgs = dt is { IsGenericType: true } ? dt.GetGenericArguments() : Type.EmptyTypes;
+                var methodArgs = closedSource.IsGenericMethod ? closedSource.GetGenericArguments() : Type.EmptyTypes;
+
+                var vector = new Type[declArgs.Length + methodArgs.Length];
+                var n = 0;
+                foreach (var t in declArgs)
+                {
+                    vector[n++] = Canonicalize(t, canon);
+                }
+                foreach (var t in methodArgs)
+                {
+                    vector[n++] = Canonicalize(t, canon);
+                }
+
+                return GenericInstantiator.CloseSource(openSource, vector);
+            }
+            catch (Exception ex)
+            {
+                MMDbgLog.Trace($"Could not construct canonical instantiation for {closedSource}: {ex.GetType().Name}: {ex.Message}");
+                return null;
+            }
+        }
+
+        // Reference types collapse to __Canon;
+        // value types are kept except a shared generic value type (e.g. a struct holding a reference type),
+        // whose arguments are canonicalized recursively so it maps onto the same shared body the runtime uses.
+        private static Type Canonicalize(Type t, Type canon)
+        {
+            if (!t.IsValueType)
+            {
+                return canon;
+            }
+            if (t.IsGenericType && GenericHelper.TypeIsShared(t))
+            {
+                var args = t.GetGenericArguments();
+                for (var i = 0; i < args.Length; i++)
+                {
+                    args[i] = Canonicalize(args[i], canon);
+                }
+                return t.GetGenericTypeDefinition().MakeGenericType(args);
+            }
+            return t;
+        }
+
+        internal static IntPtr ResolveForDispatch(int bodyId, IntPtr contextPtr)
+        {
+            return bodiesById.TryGetValue(bodyId, out var body) ? body.Resolve(contextPtr) : IntPtr.Zero;
+        }
+
+        internal static IntPtr ResolveForDispatchThis(int bodyId, object self) => bodiesById.TryGetValue(bodyId, out var body) ? body.ResolveFromThisObject(self) : IntPtr.Zero;
+
+        private static SharedDispatchTrampoline.Result BuildTopEntry(MethodBase closedSource, MethodInfo closedTarget, Delegate? orig, GenericContextReader.GenericContextKind kind)
+        {
+            // Fast path: a single replace hook on a ThisObject method can be jumped to directly, with no trampoline.
+            if (orig is null && kind == GenericContextReader.GenericContextKind.ThisObject && !RequiresReturnBuffer(closedSource))
+            {
+                RuntimeHelpers.PrepareMethod(closedTarget.MethodHandle);
+                return new SharedDispatchTrampoline.Result(PlatformTriple.Current.Runtime.GetMethodHandle(closedTarget).GetFunctionPointer(), default, closedTarget);
+            }
+
+            return SharedDispatchTrampoline.Build(closedSource, closedTarget, orig, kind);
+        }
+
+        private static void Compile(MethodBase closedSource)
+        {
+            if (PlatformDetection.Runtime == RuntimeKind.Framework)
+            {
+                // PlatformTriple.Compile throws "The given generic instantiation was invalid" here
+                // and Runtime.GetMethodHandle crashes the net472 test runner, so pass the instantiation explicitly.
+                var handle = closedSource.MethodHandle;
+                var declArgs = closedSource.DeclaringType is { IsGenericType: true } dt ? dt.GetGenericArguments() : Type.EmptyTypes;
+                var methodArgs = closedSource.IsGenericMethod ? closedSource.GetGenericArguments() : Type.EmptyTypes;
+
+                if (declArgs.Length == 0 && methodArgs.Length == 0)
+                {
+                    RuntimeHelpers.PrepareMethod(handle);
+                    return;
+                }
+
+                var all = new RuntimeTypeHandle[declArgs.Length + methodArgs.Length];
+                var n = 0;
+                foreach (var t in declArgs)
+                {
+                    all[n++] = t.TypeHandle;
+                }
+                foreach (var t in methodArgs)
+                {
+                    all[n++] = t.TypeHandle;
+                }
+
+                RuntimeHelpers.PrepareMethod(handle, all);
+            }
+            else
+            {
+                PlatformTriple.Current.Compile(closedSource);
+            }
+        }
+
+        // Used to exclude the direct-function-pointer fast path, whose static target would otherwise swap `this` and the buffer.
+        private static bool RequiresReturnBuffer(MethodBase m) => m is MethodInfo mi && GenericHelper.HasReturnBuffer(mi.ReturnType);
+
+        // The Mono context-capture stub (GenericContextCaptureStub) is implemented for x86_64 and Arm64 and is only
+        // needed on Mono for non-ThisObject kinds;
+        private bool RequiresUnportedMonoCaptureStub
+            => PlatformDetection.Runtime == RuntimeKind.Mono
+               && _kind != GenericContextReader.GenericContextKind.ThisObject
+               && PlatformDetection.Architecture is not (ArchitectureKind.x86_64 or ArchitectureKind.Arm64);
+
+        private sealed class KeyChain : IDisposable
+        {
+            public sealed class Layer
+            {
+                public MethodInfo Target = null!;
+                public bool HasOrig;
+            }
+
+            private readonly SharedBody body;
+            public InstantiationKey Key { get; }
+            private readonly MethodBase closedSource;
+            internal MethodBase ClosedSource => closedSource;
+            private readonly List<Layer> layers = [];
+
+            private GenericOrigCloner? cloner;
+            private Delegate? baseClone;
+            // Keeps the orig-via-body trampoline alive while in use.
+            private object? origViaBodyKeepAlive;
+
+            private readonly List<GCHandle> curHandles = [];
+            private readonly List<object> curKeepAlive = [];
+
+            private volatile IntPtr entry;
+            public IntPtr Entry => entry;
+
+            public KeyChain(SharedBody body, InstantiationKey key, MethodBase closedSource)
+            {
+                this.body = body;
+                Key = key;
+                this.closedSource = closedSource;
+            }
+
+            public Layer AddLayer(MethodInfo target, bool hasOrig)
+            {
+                var layer = new Layer { Target = target, HasOrig = hasOrig };
+                layers.Add(layer);
+                Rebuild();
+                return layer;
+            }
+
+            // Returns true if the chain was emptied
+            public bool RemoveLayer(Layer layer)
+            {
+                layers.Remove(layer);
+                if (layers.Count == 0)
+                {
+                    entry = IntPtr.Zero;
+                    return true;
+                }
+                Rebuild();
+                return false;
+            }
+
+            private void Rebuild()
+            {
+                RetireCurrent();
+
+                var top = layers[layers.Count - 1];
+
+                Delegate? origForTop = null;
+                if (top.HasOrig)
+                {
+                    var origDelType = top.Target.GetParameters()[0].ParameterType;
+                    EnsureBaseClone(origDelType);
+                    origForTop = FoldBelowTop(origDelType);
+                }
+
+                var result = body.BuildTop(closedSource, top.Target, origForTop);
+                if (result.OrigHandle.IsAllocated)
+                {
+                    curHandles.Add(result.OrigHandle);
+                }
+                if (result.KeepAlive is not null)
+                {
+                    curKeepAlive.Add(result.KeepAlive);
+                }
+
+                entry = result.Entry;
+            }
+
+            // Folds layers[0 .. count-2] into a single orig delegate whose bottom is the original clone
+            private Delegate FoldBelowTop(Type origDelType)
+            {
+                var current = baseClone!;
+                for (var i = 0; i < layers.Count - 1; i++)
+                {
+                    var layer = layers[i];
+                    var step = SharedDispatchTrampoline.BuildManagedChainStep(layer.Target, layer.HasOrig ? current : null, origDelType);
+
+                    if (step.InnerHandle.IsAllocated)
+                    {
+                        curHandles.Add(step.InnerHandle);
+                    }
+                    if (step.KeepAlive is not null)
+                    {
+                        curKeepAlive.Add(step.KeepAlive);
+                    }
+                    curKeepAlive.Add(step.Delegate);
+
+                    current = step.Delegate;
+                }
+                return current;
+            }
+
+            private void EnsureBaseClone(Type origDelType)
+            {
+                if (baseClone is not null)
+                {
+                    return;
+                }
+                // .NET Core only; elsewhere the detour-free concrete clone below is used.
+                if (body.TryBuildOrigViaBody(closedSource, Key, origDelType, out var viaBody, out var viaKeepAlive))
+                {
+                    baseClone = viaBody;
+                    origViaBodyKeepAlive = viaKeepAlive;
+                    return;
+                }
+                cloner = GenericOrigCloner.Create(closedSource);
+                baseClone = cloner.CreateDelegate(origDelType);
+            }
+
+            // Dispatch is lock-free, so a thread can resolve an entry and be pre-empted before the calli; these
+            // resources must not be freed while the body can still dispatch (a freed orig handle reads back null).
+            // Defer to the body's retirement list, freed at Teardown when the detour is gone.
+            // TODO: Better heuristic maybe?
+            private void RetireCurrent()
+            {
+                if (curHandles.Count == 0 && curKeepAlive.Count == 0)
+                {
+                    return;
+                }
+                foreach (var h in curHandles)
+                {
+                    body.Retire(h, null);
+                }
+                foreach (var k in curKeepAlive)
+                {
+                    body.Retire(default, k);
+                }
+                curHandles.Clear();
+                curKeepAlive.Clear();
+            }
+
+            public void Dispose()
+            {
+                entry = IntPtr.Zero;
+                RetireCurrent();
+                cloner?.Dispose();
+                cloner = null;
+                baseClone = null;
+                origViaBodyKeepAlive = null;
+            }
+        }
+    }
+}
+

--- a/src/MonoMod.RuntimeDetour/Generics/SharedDispatchTrampoline.cs
+++ b/src/MonoMod.RuntimeDetour/Generics/SharedDispatchTrampoline.cs
@@ -1,0 +1,224 @@
+﻿using MonoMod.Core.Platforms;
+using MonoMod.Utils;
+using MonoMod.Utils.Cil;
+using System;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace MonoMod.RuntimeDetour.Generics
+{
+    internal static class SharedDispatchTrampoline
+    {
+        public readonly struct Result
+        {
+            public readonly IntPtr Entry;
+            // default when no orig
+            public readonly GCHandle OrigHandle;
+            public readonly object KeepAlive;
+            public Result(IntPtr entry, GCHandle origHandle, object keepAlive)
+            {
+                Entry = entry;
+                OrigHandle = origHandle;
+                KeepAlive = keepAlive;
+            }
+        }
+        public readonly struct ChainStep
+        {
+            public readonly Delegate Delegate;
+            // default when no orig
+            public readonly GCHandle InnerHandle;
+            public readonly object KeepAlive;
+            public ChainStep(Delegate @delegate, GCHandle innerHandle, object keepAlive)
+            {
+                Delegate = @delegate;
+                InnerHandle = innerHandle;
+                KeepAlive = keepAlive;
+            }
+        }
+
+        private static readonly MethodInfo GCHandle_FromIntPtr = typeof(GCHandle).GetMethod(nameof(GCHandle.FromIntPtr), BindingFlags.Public | BindingFlags.Static, null, [typeof(IntPtr)], null)!;
+        private static readonly MethodInfo GCHandle_get_Target = typeof(GCHandle).GetProperty(nameof(GCHandle.Target))!.GetGetMethod()!;
+
+        public static Result Build(MethodBase closedSource, MethodInfo closedTarget, Delegate? orig, GenericContextReader.GenericContextKind kind)
+        {
+            var abi = PlatformTriple.Current.Abi;
+
+            var hasThis = !closedSource.IsStatic;
+            var ctxIsForwarded = GenericHelper.IsContextForwarded(kind);
+
+            var srcParams = closedSource.GetParameters();
+            var returnType = (closedSource as MethodInfo)?.ReturnType ?? typeof(void);
+            var hasReturnBuffer = GenericHelper.HasReturnBuffer(returnType);
+            var returnBufferType = hasReturnBuffer ? returnType.MakeByRefType() : returnType;
+
+            var trampParams = PlatformTriple.BuildAbiArgumentLayout(
+                abi.ArgumentOrder.Span, closedSource, srcParams,
+                hasThis, hasReturnBuffer, ctxIsForwarded, returnBufferType,
+                out var selfIdx, out var returnBufferPos, out _, out var firstUserIdx);
+
+            var retBufIsArg = hasReturnBuffer && returnBufferPos >= 0;
+            var newReturnType = retBufIsArg
+                ? (abi.ReturnsReturnBuffer ? returnBufferType : typeof(void))
+                : returnType;
+
+            var origHandle = default(GCHandle);
+            using var dmd = new DynamicMethodDefinition($"SharedGenericDispatch<{closedTarget}>", newReturnType, trampParams);
+            try
+            {
+                var il = new CecilILGenerator(dmd.Definition.Body.GetILProcessor());
+
+                if (retBufIsArg)
+                {
+                    Ldarg(il, returnBufferPos);
+                }
+
+                if (orig is not null)
+                {
+                    var origParamType = closedTarget.GetParameters()[0].ParameterType;
+                    origHandle = GCHandle.Alloc(orig);
+                    EmitLoadGCHandleTarget(il, GCHandle.ToIntPtr(origHandle), origParamType);
+                }
+
+                if (hasThis)
+                {
+                    Ldarg(il, selfIdx);
+                }
+
+                for (var i = 0; i < srcParams.Length; i++)
+                {
+                    Ldarg(il, firstUserIdx + i);
+                }
+
+                il.Emit(OpCodes.Call, closedTarget);
+
+                if (retBufIsArg)
+                {
+                    il.Emit(OpCodes.Stobj, returnType);
+                    if (abi.ReturnsReturnBuffer)
+                    {
+                        Ldarg(il, returnBufferPos);
+                    }
+                }
+
+                il.Emit(OpCodes.Ret);
+
+                // Generated via DMDCecilGenerator because DynamicMethod.MethodHandle throws.
+                var generated = DMDCecilGenerator.Generate(dmd);
+
+                RuntimeHelpers.PrepareMethod(generated.MethodHandle);
+                var entry = generated.MethodHandle.GetFunctionPointer();
+
+                return new Result(entry, origHandle, generated);
+            }
+            catch
+            {
+                if (origHandle.IsAllocated)
+                {
+                    origHandle.Free();
+                }
+
+                throw;
+            }
+        }
+
+        public static ChainStep BuildManagedChainStep(MethodInfo closedTarget, Delegate? innerOrig, Type origDelegateType)
+        {
+            var srcParams = origDelegateType.GetMethod("Invoke") ?? throw new InvalidOperationException($"{origDelegateType} has no Invoke method.");
+            var invokeParams = srcParams.GetParameters();
+            var trampParams = new Type[invokeParams.Length];
+            for (var i = 0; i < invokeParams.Length; i++)
+            {
+                trampParams[i] = invokeParams[i].ParameterType;
+            }
+            var returnType = srcParams.ReturnType;
+
+            var innerHandle = default(GCHandle);
+            using var dmd = new DynamicMethodDefinition($"SharedGenericChainStep<{closedTarget}>", returnType, trampParams);
+            try
+            {
+                var il = new CecilILGenerator(dmd.Definition.Body.GetILProcessor());
+
+                if (innerOrig is not null)
+                {
+                    var origParamType = closedTarget.GetParameters()[0].ParameterType;
+                    innerHandle = GCHandle.Alloc(innerOrig);
+                    EmitLoadGCHandleTarget(il, GCHandle.ToIntPtr(innerHandle), origParamType);
+                }
+
+                for (var i = 0; i < trampParams.Length; i++)
+                {
+                    Ldarg(il, i);
+                }
+
+                il.Emit(OpCodes.Call, closedTarget);
+                il.Emit(OpCodes.Ret);
+
+                var generated = DMDCecilGenerator.Generate(dmd);
+                RuntimeHelpers.PrepareMethod(generated.MethodHandle);
+                var del = generated.CreateDelegate(origDelegateType);
+
+                return new ChainStep(del, innerHandle, generated);
+            }
+            catch
+            {
+                if (innerHandle.IsAllocated)
+                {
+                    innerHandle.Free();
+                }
+
+                throw;
+            }
+        }
+
+        private static void EmitLoadGCHandleTarget(ILGeneratorShim il, IntPtr handlePtr, Type castTo)
+        {
+            if (IntPtr.Size == 8)
+            {
+                il.Emit(OpCodes.Ldc_I8, (long)handlePtr);
+            }
+            else
+            {
+                il.Emit(OpCodes.Ldc_I4, (int)handlePtr);
+            }
+
+            il.Emit(OpCodes.Conv_I);
+            il.Emit(OpCodes.Call, GCHandle_FromIntPtr);
+            var loc = il.DeclareLocal(typeof(GCHandle));
+            il.Emit(OpCodes.Stloc, loc);
+            il.Emit(OpCodes.Ldloca, loc);
+            il.Emit(OpCodes.Call, GCHandle_get_Target);
+            il.Emit(OpCodes.Castclass, castTo);
+        }
+
+        private static void Ldarg(ILGeneratorShim il, int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    il.Emit(OpCodes.Ldarg_0);
+                    break;
+                case 1:
+                    il.Emit(OpCodes.Ldarg_1);
+                    break;
+                case 2:
+                    il.Emit(OpCodes.Ldarg_2);
+                    break;
+                case 3:
+                    il.Emit(OpCodes.Ldarg_3);
+                    break;
+                default:
+                    if (index <= byte.MaxValue)
+                    {
+                        il.Emit(OpCodes.Ldarg_S, (byte)index);
+                    }
+                    else
+                    {
+                        il.Emit(OpCodes.Ldarg, checked((short)index));
+                    }
+                    break;
+            }
+        }
+    }
+}

--- a/src/MonoMod.RuntimeDetour/Generics/UniversalDispatcher.cs
+++ b/src/MonoMod.RuntimeDetour/Generics/UniversalDispatcher.cs
@@ -1,0 +1,250 @@
+using MonoMod.Utils;
+using System;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using Mono.Cecil.Cil;
+using MonoMod.Core.Platforms;
+
+namespace MonoMod.RuntimeDetour.Generics
+{
+    // Builds the per-body managed dispatcher the shared native body is detoured to.
+    // The dispatcher reads the generic context (from its argument, or from this for the ThisObject kind),
+    // resolves the target entry, then forwards via calli
+    // On Mono the context arrives via the capture stub and is read but NOT forwarded.
+    internal static class UniversalDispatcher
+    {
+        public readonly struct Result
+        {
+            public readonly IntPtr Entry;
+            public readonly object KeepAlive;
+            // For Mono: the integer-argument-register index the capture stub must move the generic context into;
+            // -1 when no capture stub is needed (CoreCLR/Framework, or the ThisObject kind).
+            public readonly int ContextArgRegisterIndex;
+            public Result(IntPtr entry, object keepAlive, int contextArgRegisterIndex)
+            {
+                Entry = entry;
+                KeepAlive = keepAlive;
+                ContextArgRegisterIndex = contextArgRegisterIndex;
+            }
+        }
+
+        private static readonly MethodInfo resolveForDispatch = ((Func<int, IntPtr, IntPtr>)SharedBodyDispatcher.ResolveForDispatch).Method;
+        private static readonly MethodInfo resolveForDispatchThis = ((Func<int, object, IntPtr>)SharedBodyDispatcher.ResolveForDispatchThis).Method;
+        private static readonly ConstructorInfo invalidOpCtor = typeof(InvalidOperationException).GetConstructor([typeof(string)])!;
+
+        public static Result Build(MethodBase closedSource, GenericContextReader.GenericContextKind kind, int bodyId)
+        {
+            Helpers.ThrowIfArgumentNull(closedSource);
+
+            var abi = PlatformTriple.Current.Abi;
+
+            var hasThis = !closedSource.IsStatic;
+            var explicitCtx = kind != GenericContextReader.GenericContextKind.ThisObject;
+            var isMono = PlatformDetection.Runtime == RuntimeKind.Mono;
+            // The context is forwarded (as a real argument) only on CoreCLR/Framework.
+            // On Mono it came from r10 and is consumed here.
+            var ctxIsForwarded = GenericHelper.IsContextForwarded(kind);
+
+            var returnType = (closedSource as MethodInfo)?.ReturnType ?? typeof(void);
+            var hasReturnBuffer = GenericHelper.HasReturnBuffer(returnType);
+            var returnBufferType = hasReturnBuffer ? returnType.MakeByRefType() : returnType;
+
+            // On Mono the ABI argument order has no generic-context slot (it's in r10);
+            // append one so we have an argument to read it from. Elsewhere the ABI order already places it.
+            ReadOnlySpan<SpecialArgumentKind> order;
+            if (explicitCtx && isMono)
+            {
+                var baseOrder = abi.ArgumentOrder.Span;
+                var appended = new SpecialArgumentKind[baseOrder.Length + 1];
+                baseOrder.CopyTo(appended);
+                appended[baseOrder.Length] = SpecialArgumentKind.GenericContext;
+                order = appended;
+            }
+            else
+            {
+                order = abi.ArgumentOrder.Span;
+            }
+
+            var parameters = closedSource.GetParameters();
+            var paramTypes = PlatformTriple.BuildAbiArgumentLayout(
+                order, closedSource, parameters,
+                hasThis, hasReturnBuffer, explicitCtx, returnBufferType,
+                out var thisPos, out var returnBufferPos, out var genCtxPos, out _,
+                Canonical);
+
+            var retBufIsArg = hasReturnBuffer && returnBufferPos >= 0;
+            var newReturnType = retBufIsArg
+                ? (abi.ReturnsReturnBuffer ? returnBufferType : typeof(void))
+                : returnType;
+
+            using var dmd = new DynamicMethodDefinition($"UniversalGenericDispatch<{closedSource}>", newReturnType, paramTypes);
+            var module = dmd.Module;
+            var il = dmd.GetILProcessor();
+            var dmParams = dmd.Definition.Parameters;
+
+            var entryLocal = new VariableDefinition(module.ImportReference(typeof(IntPtr)));
+            dmd.Definition.Body.Variables.Add(entryLocal);
+
+            // entry = Resolve...(bodyId, context | this)
+            il.Emit(OpCodes.Ldc_I4, bodyId);
+            if (explicitCtx)
+            {
+                il.Emit(OpCodes.Ldarg, dmParams[genCtxPos]);
+                il.Emit(OpCodes.Call, module.ImportReference(resolveForDispatch));
+            }
+            else
+            {
+                il.Emit(OpCodes.Ldarg, dmParams[thisPos]);
+                il.Emit(OpCodes.Call, module.ImportReference(resolveForDispatchThis));
+            }
+            il.Emit(OpCodes.Stloc, entryLocal);
+
+            var notNull = Instruction.Create(OpCodes.Nop);
+            il.Emit(OpCodes.Ldloc, entryLocal);
+            il.Emit(OpCodes.Brtrue, notNull);
+            il.Emit(OpCodes.Ldstr, $"Generic dispatch for {closedSource} resolved to a null target (generic-context read or fallback build failed).");
+            il.Emit(OpCodes.Newobj, module.ImportReference(invalidOpCtor));
+            il.Emit(OpCodes.Throw);
+            il.Append(notNull);
+
+            var callSite = new Mono.Cecil.CallSite(module.ImportReference(newReturnType));
+            for (var i = 0; i < paramTypes.Length; i++)
+            {
+                if (i == genCtxPos && !ctxIsForwarded)
+                {
+                    continue;
+                }
+                il.Emit(OpCodes.Ldarg, dmParams[i]);
+                callSite.Parameters.Add(new Mono.Cecil.ParameterDefinition(module.ImportReference(paramTypes[i])));
+            }
+            il.Emit(OpCodes.Ldloc, entryLocal);
+            il.Emit(OpCodes.Calli, callSite);
+            il.Emit(OpCodes.Ret);
+
+            var generated = DMDCecilGenerator.Generate(dmd);
+            RuntimeHelpers.PrepareMethod(generated.MethodHandle);
+            var entry = generated.MethodHandle.GetFunctionPointer();
+
+            var ctxRegIndex = -1;
+            if (explicitCtx && isMono)
+            {
+                ctxRegIndex = MonoContextRegisterCalibrator.TryFindContextArgRegister(paramTypes, genCtxPos) ?? CountIntegerArgRegistersBefore(paramTypes, genCtxPos);
+            }
+
+            return new Result(entry, generated, ctxRegIndex);
+        }
+
+        // Fallback approximation when calibration is unavailable: count of integer argument registers consumed by the
+        // slots preceding the generic context; FP args are assumed to use FP registers and are skipped.
+        // TODO: Find a proper not hacky implementation
+        private static int CountIntegerArgRegistersBefore(Type[] paramTypes, int genCtxPos)
+        {
+            var count = 0;
+            for (var i = 0; i < genCtxPos; i++)
+            {
+                var t = paramTypes[i];
+                if (t == typeof(float) || t == typeof(double))
+                {
+                    continue;
+                }
+                count++;
+            }
+            return count;
+        }
+
+        private static Type Canonical(Type t) => t.IsByRef || t.IsValueType ? t : typeof(object);
+
+        // Build the orig delegate as a direct call into the original shared body with this instantiation's fixed generic context,
+        // instead of cloning the concrete method's IL.
+        public static (Delegate Orig, object KeepAlive) BuildOrigViaBody(MethodBase closedSource, IntPtr origEntrypoint, IntPtr fixedContext, Type origDelType)
+        {
+            Helpers.ThrowIfArgumentNull(closedSource);
+            var abi = PlatformTriple.Current.Abi;
+
+            var hasThis = !closedSource.IsStatic;
+            var srcParams = closedSource.GetParameters();
+            var returnType = (closedSource as MethodInfo)?.ReturnType ?? typeof(void);
+            var hasReturnBuffer = GenericHelper.HasReturnBuffer(returnType);
+            var returnBufferType = hasReturnBuffer ? returnType.MakeByRefType() : returnType;
+
+            var calliParams = PlatformTriple.BuildAbiArgumentLayout(
+                abi.ArgumentOrder.Span, closedSource, srcParams,
+                hasThis, hasReturnBuffer, true, returnBufferType,
+                out var thisPos, out var returnBufferPos, out var genCtxPos, out var userArgsOffset);
+
+            var retBufIsArg = hasReturnBuffer && returnBufferPos >= 0;
+            var newReturnType = retBufIsArg
+                ? (abi.ReturnsReturnBuffer ? returnBufferType : typeof(void))
+                : returnType;
+
+            var invoke = origDelType.GetMethod("Invoke") ?? throw new InvalidOperationException($"{origDelType} has no Invoke method.");
+            var managedParams = Array.ConvertAll(invoke.GetParameters(), p => p.ParameterType);
+            var managedReturn = invoke.ReturnType;
+            var firstUserManaged = hasThis ? 1 : 0;
+
+            using var dmd = new DynamicMethodDefinition($"SharedGenericOrigViaBody<{closedSource}>", managedReturn, managedParams);
+            var module = dmd.Module;
+            var il = dmd.GetILProcessor();
+            var dmParams = dmd.Definition.Parameters;
+
+            VariableDefinition? retLocal = null;
+            if (retBufIsArg)
+            {
+                retLocal = new VariableDefinition(module.ImportReference(returnType));
+                dmd.Definition.Body.Variables.Add(retLocal);
+            }
+
+            var callSite = new Mono.Cecil.CallSite(module.ImportReference(newReturnType));
+            for (var i = 0; i < calliParams.Length; i++)
+            {
+                if (i == thisPos)
+                {
+                    il.Emit(OpCodes.Ldarg, dmParams[0]);
+                }
+                else if (i == returnBufferPos)
+                {
+                    il.Emit(OpCodes.Ldloca, retLocal!);
+                }
+                else if (i == genCtxPos)
+                {
+                    EmitLdcIntPtr(il, fixedContext);
+                }
+                else
+                {
+                    il.Emit(OpCodes.Ldarg, dmParams[firstUserManaged + (i - userArgsOffset)]);
+                }
+                callSite.Parameters.Add(new Mono.Cecil.ParameterDefinition(module.ImportReference(calliParams[i])));
+            }
+
+            EmitLdcIntPtr(il, origEntrypoint);
+            il.Emit(OpCodes.Calli, callSite);
+
+            if (retBufIsArg)
+            {
+                if (abi.ReturnsReturnBuffer)
+                {
+                    il.Emit(OpCodes.Pop);
+                }
+                il.Emit(OpCodes.Ldloc, retLocal!);
+            }
+            il.Emit(OpCodes.Ret);
+
+            var generated = DMDCecilGenerator.Generate(dmd);
+            RuntimeHelpers.PrepareMethod(generated.MethodHandle);
+            return (generated.CreateDelegate(origDelType), generated);
+        }
+
+        private static void EmitLdcIntPtr(Mono.Cecil.Cil.ILProcessor il, IntPtr value)
+        {
+            if (IntPtr.Size == 8)
+            {
+                il.Emit(OpCodes.Ldc_I8, (long)value);
+            }
+            else
+            {
+                il.Emit(OpCodes.Ldc_I4, (int)value);
+            }
+            il.Emit(OpCodes.Conv_I);
+        }
+    }
+}

--- a/src/MonoMod.RuntimeDetour/Hook.cs
+++ b/src/MonoMod.RuntimeDetour/Hook.cs
@@ -549,6 +549,11 @@ namespace MonoMod.RuntimeDetour
         /// <param name="config">The <see cref="DetourConfig"/> to use for this <see cref="Hook"/>.</param>
         /// <param name="applyByDefault">Whether or not this hook should be applied when the constructor finishes.</param>
         public Hook(MethodBase source, MethodInfo target, object? targetObject, IDetourFactory factory, DetourConfig? config, bool applyByDefault)
+            : this(source, target, targetObject, factory, config, applyByDefault, false)
+        {
+        }
+
+        internal Hook(MethodBase source, MethodInfo target, object? targetObject, IDetourFactory factory, DetourConfig? config, bool applyByDefault, bool allowGeneric)
         {
             Helpers.ThrowIfArgumentNull(source);
             Helpers.ThrowIfArgumentNull(target);
@@ -558,6 +563,15 @@ namespace MonoMod.RuntimeDetour
             Config = config;
             Source = PlatformTriple.Current.GetIdentifiable(source);
             Target = target;
+
+            if (!allowGeneric)
+            {
+                CheckSupported();
+            }
+            else if (Source.ContainsGenericParameters)
+            {
+                throw new ArgumentException("Cannot hook an open generic definition");
+            }
 
             realTarget = PrepareRealTarget(targetObject, out trampoline, out delegateObjectScope);
 
@@ -588,8 +602,6 @@ namespace MonoMod.RuntimeDetour
 
         private MethodInfo PrepareRealTarget(object? target, out TrampolineData trampoline, out DataScope<DynamicReferenceCell> scope)
         {
-            CheckSupported();
-
             var srcSig = MethodSignature.ForMethod(Source);
             var dstSig = MethodSignature.ForMethod(Target, ignoreThis: true); // the dest sig we don't want to consider its this param
 

--- a/src/MonoMod.UnitTest/RuntimeDetour/Generics/GenericHookArgRegisterPackingTest.cs
+++ b/src/MonoMod.UnitTest/RuntimeDetour/Generics/GenericHookArgRegisterPackingTest.cs
@@ -1,0 +1,73 @@
+extern alias New;
+using New::MonoMod.RuntimeDetour.Generics;
+using System;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace MonoMod.UnitTest.RuntimeDetour.Generics
+{
+    [Collection("RuntimeDetour")]
+    public class GenericHookArgRegisterPackingTest(ITestOutputHelper helper) : GenericTestBase(helper)
+    {
+
+        private static GenericHook Hook(MethodInfo src, string targetName, params Type[][] vectors) => new(src, GetMethod(typeof(GenericHookArgRegisterPackingTest), targetName), vectors);
+
+        public struct Pair
+        {
+            public long A;
+            public long B;
+        }
+
+        public static class PackSrc
+        {
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            public static string StructThenGeneric<T>(Pair p, T value) => $"orig<{typeof(T).Name}>:{p.A},{p.B}:{value}";
+
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            public static string StructThenGenericOrig<T>(Pair p, T value) => $"orig<{typeof(T).Name}>:{p.A},{p.B}:{value}";
+
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            public static string FloatsThenGeneric<T>(double d1, double d2, T value) => $"orig<{typeof(T).Name}>:{d1},{d2}:{value}";
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        internal static string StructThenGenericHook<T>(Pair p, T value) => $"hook<{typeof(T).Name}>:{p.A},{p.B}:{value}";
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        internal static string StructThenGenericWrap<T>(Func<Pair, T, string> orig, Pair p, T value) => $"wrap[{orig(p, value)}]";
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        internal static string FloatsThenGenericHook<T>(double d1, double d2, T value) => $"hook<{typeof(T).Name}>:{d1},{d2}:{value}";
+
+        [GenericHookFact]
+        public void TwoWordStructBeforeGenericArg()
+        {
+            var src = GetMethod(typeof(PackSrc), nameof(PackSrc.StructThenGeneric));
+            using var hook = Hook(src, nameof(StructThenGenericHook), [typeof(string)]);
+
+            var p = new Pair { A = 11, B = 22 };
+            Assert.Equal("hook<String>:11,22:x", PackSrc.StructThenGeneric(p, "x"));
+        }
+
+        [GenericHookFact]
+        public void TwoWordStructBeforeGenericArgWithOrig()
+        {
+            var src = GetMethod(typeof(PackSrc), nameof(PackSrc.StructThenGenericOrig));
+            using var hook = Hook(src, nameof(StructThenGenericWrap), [typeof(string)]);
+
+            var p = new Pair { A = 11, B = 22 };
+            Assert.Equal("wrap[orig<String>:11,22:x]", PackSrc.StructThenGenericOrig(p, "x"));
+        }
+
+        [GenericHookFact]
+        public void FloatsBeforeGenericArg()
+        {
+            var src = GetMethod(typeof(PackSrc), nameof(PackSrc.FloatsThenGeneric));
+            using var hook = Hook(src, nameof(FloatsThenGenericHook), [typeof(string)]);
+
+            Assert.Equal("hook<String>:1,2:x", PackSrc.FloatsThenGeneric(1.0, 2.0, "x"));
+        }
+    }
+}

--- a/src/MonoMod.UnitTest/RuntimeDetour/Generics/GenericHookConcurrencyTest.cs
+++ b/src/MonoMod.UnitTest/RuntimeDetour/Generics/GenericHookConcurrencyTest.cs
@@ -1,0 +1,247 @@
+extern alias New;
+using New::MonoMod.RuntimeDetour.Generics;
+using System;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.ExceptionServices;
+using System.Threading;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace MonoMod.UnitTest.RuntimeDetour.Generics
+{
+    [Collection("RuntimeDetour")]
+    public class GenericHookConcurrencyTest(ITestOutputHelper helper) : GenericTestBase(helper)
+    {
+        private static MethodInfo GenSrc => GetMethod(typeof(ConcSrc), nameof(ConcSrc.Gen));
+        private static MethodInfo TierGenSrc => GetMethod(typeof(ConcSrc), nameof(ConcSrc.TierGen));
+        private static MethodInfo TierGenWSrc => GetMethod(typeof(ConcSrc), nameof(ConcSrc.TierGenW));
+        private static MethodInfo ReplaceTgt => GetMethod(typeof(GenericHookConcurrencyTest), nameof(Replace));
+        private static MethodInfo WrapTgt => GetMethod(typeof(GenericHookConcurrencyTest), nameof(Wrap));
+
+        public static class ConcSrc
+        {
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            public static string Gen<T>(T value) => $"orig<{typeof(T).Name}>:{value}";
+
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            public static string TierGen<T>(T value) => $"orig<{typeof(T).Name}>:{value}";
+
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            public static string TierGenW<T>(T value) => $"orig<{typeof(T).Name}>:{value}";
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        internal static string Replace<T>(T value) => $"hook<{typeof(T).Name}>:{value}";
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        internal static string Wrap<T>(Func<T, string> orig, T value) => $"wrap[{orig(value)}]";
+
+        public sealed class R0
+        {
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            public override string ToString() => "r0";
+        }
+        public sealed class R1
+        {
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            public override string ToString() => "r1";
+        }
+        public sealed class R2
+        {
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            public override string ToString() => "r2";
+        }
+        public sealed class R3
+        {
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            public override string ToString() => "r3";
+        }
+        public sealed class R4
+        {
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            public override string ToString() => "r4";
+        }
+        public sealed class R5
+        {
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            public override string ToString() => "r5";
+        }
+
+        private static readonly object s_obj = new();
+        private static readonly R0 s_r0 = new();
+        private static readonly R1 s_r1 = new();
+        private static readonly R2 s_r2 = new();
+        private static readonly R3 s_r3 = new();
+        private static readonly R4 s_r4 = new();
+        private static readonly R5 s_r5 = new();
+        private static void AssertWellFormed(string typeName, string value, string result)
+            => Assert.True(
+                result == $"hook<{typeName}>:{value}" || result == $"orig<{typeName}>:{value}",
+                $"Unexpected dispatch result for <{typeName}>: '{result}'");
+
+        private static void CheckCall(int k)
+        {
+            switch (k % 8)
+            {
+                case 0: AssertWellFormed("String", "s", ConcSrc.Gen<string>("s")); break;
+                case 1: AssertWellFormed("Object", s_obj.ToString()!, ConcSrc.Gen<object>(s_obj)); break;
+                case 2: AssertWellFormed("R0", "r0", ConcSrc.Gen<R0>(s_r0)); break;
+                case 3: AssertWellFormed("R1", "r1", ConcSrc.Gen<R1>(s_r1)); break;
+                case 4: AssertWellFormed("R2", "r2", ConcSrc.Gen<R2>(s_r2)); break;
+                case 5: AssertWellFormed("R3", "r3", ConcSrc.Gen<R3>(s_r3)); break;
+                case 6: AssertWellFormed("R4", "r4", ConcSrc.Gen<R4>(s_r4)); break;
+                default: AssertWellFormed("R5", "r5", ConcSrc.Gen<R5>(s_r5)); break;
+            }
+        }
+
+        private static void Stress(int threads, int iters, Action<int, int> body)
+        {
+            using var gate = new Barrier(threads + 1);
+            Exception? failure = null;
+            var workers = new Thread[threads];
+            for (var t = 0; t < threads; t++)
+            {
+                var tid = t;
+                workers[t] = new Thread(() =>
+                {
+                    gate.SignalAndWait();
+                    try
+                    {
+                        for (var i = 0; i < iters && Volatile.Read(ref failure) is null; i++)
+                        {
+                            body(tid, i);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        Interlocked.CompareExchange(ref failure, ex, null);
+                    }
+                }) { IsBackground = true, Name = $"stress-{t}" };
+                workers[t].Start();
+            }
+            gate.SignalAndWait();
+            foreach (var w in workers)
+            {
+                w.Join();
+            }
+            if (failure is not null)
+            {
+                ExceptionDispatchInfo.Capture(failure).Throw();
+            }
+        }
+
+        [GenericHookFact]
+        public void ConcurrentDispatchIsStable()
+        {
+            using var hook = new GenericHook(GenSrc, ReplaceTgt,
+                [[typeof(string)], [typeof(object)]]);
+
+            Stress(8, 20000, (tid, i) =>
+            {
+                AssertWellFormed("String", "s", ConcSrc.Gen<string>("s"));
+                AssertWellFormed("Object", s_obj.ToString()!, ConcSrc.Gen<object>(s_obj));
+            });
+        }
+
+        [GenericHookFact]
+        public void ConcurrentReprimeAndDispatchDoesNotCorrupt()
+        {
+            using var baseHook = new GenericHook(GenSrc, WrapTgt, [[typeof(string)]]);
+
+            var stop = 0;
+            var churnFailure = null as Exception;
+            var churner = new Thread(() =>
+            {
+                try
+                {
+                    while (Volatile.Read(ref stop) == 0)
+                    {
+                        using var h = new GenericHook(GenSrc, WrapTgt, [[typeof(string)]]);
+                        _ = ConcSrc.Gen<string>("y");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    churnFailure = ex;
+                }
+            })
+            { IsBackground = true, Name = "churner" };
+            churner.Start();
+            try
+            {
+                Stress(6, 15000, (tid, i) =>
+                {
+                    var r = ConcSrc.Gen<string>("x");
+                    Assert.Contains("orig<String>:x", r, StringComparison.InvariantCulture);
+                });
+            }
+            finally
+            {
+                Volatile.Write(ref stop, 1);
+                churner.Join();
+            }
+            Assert.Null(churnFailure);
+        }
+
+        [GenericHookFact]
+        public void ConcurrentAutoDiscoveryIsSafe()
+        {
+            using var hook = new GenericHook(GenSrc, ReplaceTgt,
+                new[] { new[] { typeof(string) } }, AutoPrimeMode.All);
+
+            Stress(8, 8000, (tid, i) => CheckCall(i + tid));
+        }
+
+        [GenericHookFact]
+        public void SharedBodyDetourSurvivesTieredRecompilation()
+        {
+            using var hook = new GenericHook(TierGenSrc, ReplaceTgt, [[typeof(string)]]);
+
+            Assert.Equal("hook<String>:s", ConcSrc.TierGen<string>("s"));
+
+            for (var i = 0; i < 60_000; i++)
+            {
+                _ = ConcSrc.TierGen<string>("s");
+            }
+            Thread.Sleep(500);
+            for (var i = 0; i < 20_000; i++)
+            {
+                _ = ConcSrc.TierGen<string>("s");
+            }
+
+            for (var i = 0; i < 2_000; i++)
+            {
+                Assert.Equal("hook<String>:s", ConcSrc.TierGen<string>("s"));
+            }
+
+            hook.Dispose();
+            Assert.Equal("orig<String>:s", ConcSrc.TierGen<string>("s"));
+            using var rehook = new GenericHook(TierGenSrc, ReplaceTgt, [[typeof(string)]]);
+            Assert.Equal("hook<String>:s", ConcSrc.TierGen<string>("s"));
+        }
+
+        [GenericHookFact]
+        public void SharedBodyWithOrigSurvivesTieredRecompilation()
+        {
+            using var hook = new GenericHook(TierGenWSrc, WrapTgt, [[typeof(string)]]);
+
+            Assert.Equal("wrap[orig<String>:s]", ConcSrc.TierGenW<string>("s"));
+
+            for (var i = 0; i < 60_000; i++)
+            {
+                _ = ConcSrc.TierGenW<string>("s");
+            }
+            Thread.Sleep(500);
+            for (var i = 0; i < 20_000; i++)
+            {
+                _ = ConcSrc.TierGenW<string>("s");
+            }
+
+            for (var i = 0; i < 2_000; i++)
+            {
+                Assert.Equal("wrap[orig<String>:s]", ConcSrc.TierGenW<string>("s"));
+            }
+        }
+    }
+}

--- a/src/MonoMod.UnitTest/RuntimeDetour/Generics/GenericHookContainerParamTest.cs
+++ b/src/MonoMod.UnitTest/RuntimeDetour/Generics/GenericHookContainerParamTest.cs
@@ -1,0 +1,199 @@
+extern alias New;
+using New::MonoMod.RuntimeDetour.Generics;
+using System;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace MonoMod.UnitTest.RuntimeDetour.Generics
+{
+    [Collection("RuntimeDetour")]
+    public class GenericHookContainerParamTest(ITestOutputHelper helper) : GenericTestBase(helper)
+    {
+
+        private static GenericHook Hook(MethodInfo src, string targetName, params Type[][] vectors) => new(src, GetMethod(typeof(GenericHookContainerParamTest), targetName), vectors);
+
+        private static GenericHook Hook(MethodInfo src, string targetName, AutoPrimeMode mode, params Type[][] vectors) => new(src, GetMethod(typeof(GenericHookContainerParamTest), targetName), vectors, mode);
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        internal static string RefBoxWrap<K>(Func<K, RefBox<K>, string> orig, K par1, RefBox<K> par2) => $"wrap[{orig(par1, par2)}]";
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        internal static string ValBoxWrap<K>(Func<K, ValBox<K>, string> orig, K par1, ValBox<K> par2) => $"wrap[{orig(par1, par2)}]";
+
+        [GenericHookFact]
+        public void RefContainerValueKeyNone()
+        {
+            var src = GetMethod(typeof(RefBoxSrc), nameof(RefBoxSrc.ValNone));
+            Assert.False(IsShared(src, typeof(int)));
+
+            using var hook = Hook(src, nameof(RefBoxWrap), AutoPrimeMode.None, [typeof(int)]);
+            Assert.Equal("wrap[orig<Int32>:5|RefBox(5)]", RefBoxSrc.ValNone<int>(5, new RefBox<int>(5)));
+            Assert.Equal("orig<Int64>:7|RefBox(7)", RefBoxSrc.ValNone<long>(7L, new RefBox<long>(7L)));
+        }
+
+        [GenericHookFact]
+        public void RefContainerValueKeyCompatible()
+        {
+            var src = GetMethod(typeof(RefBoxSrc), nameof(RefBoxSrc.ValCompatible));
+            using var hook = Hook(src, nameof(RefBoxWrap), AutoPrimeMode.Compatible, [typeof(int)]);
+
+            Assert.Equal("wrap[orig<Int32>:5|RefBox(5)]", RefBoxSrc.ValCompatible<int>(5, new RefBox<int>(5)));
+            Assert.Equal("orig<Int64>:7|RefBox(7)", RefBoxSrc.ValCompatible<long>(7L, new RefBox<long>(7L)));
+        }
+
+        [GenericHookFact]
+        public void RefContainerValueKeyAll()
+        {
+            var src = GetMethod(typeof(RefBoxSrc), nameof(RefBoxSrc.ValAll));
+            using var hook = Hook(src, nameof(RefBoxWrap), AutoPrimeMode.All, [typeof(int)]);
+
+            Assert.Equal("wrap[orig<Int32>:5|RefBox(5)]", RefBoxSrc.ValAll<int>(5, new RefBox<int>(5)));
+            Assert.Equal("orig<Int64>:7|RefBox(7)", RefBoxSrc.ValAll<long>(7L, new RefBox<long>(7L)));
+        }
+
+        [GenericHookFact]
+        public void RefContainerRefKeyNone()
+        {
+            var src = GetMethod(typeof(RefBoxSrc), nameof(RefBoxSrc.RefNone));
+            Assert.True(IsShared(src, typeof(GenBase)));
+
+            using var hook = Hook(src, nameof(RefBoxWrap), AutoPrimeMode.None, [typeof(GenBase)]);
+            Assert.Equal("wrap[orig<GenBase>:B|RefBox(B)]", RefBoxSrc.RefNone<GenBase>(new GenBase(), new RefBox<GenBase>(new GenBase())));
+            Assert.Equal("orig<GenDerived>:D|RefBox(D)", RefBoxSrc.RefNone<GenDerived>(new GenDerived(), new RefBox<GenDerived>(new GenDerived())));
+        }
+
+        [GenericHookFact]
+        public void RefContainerRefKeyCompatible()
+        {
+            var src = GetMethod(typeof(RefBoxSrc), nameof(RefBoxSrc.RefCompatible));
+            using var hook = Hook(src, nameof(RefBoxWrap), AutoPrimeMode.Compatible, [typeof(GenBase)]);
+
+            Assert.Equal("wrap[orig<GenBase>:B|RefBox(B)]", RefBoxSrc.RefCompatible<GenBase>(new GenBase(), new RefBox<GenBase>(new GenBase())));
+            Assert.Equal("wrap[orig<GenDerived>:D|RefBox(D)]", RefBoxSrc.RefCompatible<GenDerived>(new GenDerived(), new RefBox<GenDerived>(new GenDerived())));
+            Assert.Equal("orig<GenUnrelated>:U|RefBox(U)", RefBoxSrc.RefCompatible<GenUnrelated>(new GenUnrelated(), new RefBox<GenUnrelated>(new GenUnrelated())));
+        }
+
+        [GenericHookFact]
+        public void RefContainerRefKeyAll()
+        {
+            var src = GetMethod(typeof(RefBoxSrc), nameof(RefBoxSrc.RefAll));
+            using var hook = Hook(src, nameof(RefBoxWrap), AutoPrimeMode.All, [typeof(GenBase)]);
+
+            Assert.Equal("wrap[orig<GenBase>:B|RefBox(B)]", RefBoxSrc.RefAll<GenBase>(new GenBase(), new RefBox<GenBase>(new GenBase())));
+            Assert.Equal("wrap[orig<GenDerived>:D|RefBox(D)]", RefBoxSrc.RefAll<GenDerived>(new GenDerived(), new RefBox<GenDerived>(new GenDerived())));
+            Assert.Equal("wrap[orig<GenUnrelated>:U|RefBox(U)]", RefBoxSrc.RefAll<GenUnrelated>(new GenUnrelated(), new RefBox<GenUnrelated>(new GenUnrelated())));
+        }
+
+        [GenericHookFact]
+        public void ValueContainerValueKeyNone()
+        {
+            var src = GetMethod(typeof(ValBoxSrc), nameof(ValBoxSrc.ValNone));
+            Assert.False(IsShared(src, typeof(int)));
+
+            using var hook = Hook(src, nameof(ValBoxWrap), AutoPrimeMode.None, [typeof(int)]);
+            Assert.Equal("wrap[orig<Int32>:5|ValBox(5)]", ValBoxSrc.ValNone<int>(5, new ValBox<int>(5)));
+            Assert.Equal("orig<Int64>:7|ValBox(7)", ValBoxSrc.ValNone<long>(7L, new ValBox<long>(7L)));
+        }
+
+        [GenericHookFact]
+        public void ValueContainerValueKeyCompatible()
+        {
+            var src = GetMethod(typeof(ValBoxSrc), nameof(ValBoxSrc.ValCompatible));
+            using var hook = Hook(src, nameof(ValBoxWrap), AutoPrimeMode.Compatible, [typeof(int)]);
+
+            Assert.Equal("wrap[orig<Int32>:5|ValBox(5)]", ValBoxSrc.ValCompatible<int>(5, new ValBox<int>(5)));
+            Assert.Equal("orig<Int64>:7|ValBox(7)", ValBoxSrc.ValCompatible<long>(7L, new ValBox<long>(7L)));
+        }
+
+        [GenericHookFact]
+        public void ValueContainerValueKeyAll()
+        {
+            var src = GetMethod(typeof(ValBoxSrc), nameof(ValBoxSrc.ValAll));
+            using var hook = Hook(src, nameof(ValBoxWrap), AutoPrimeMode.All, [typeof(int)]);
+
+            Assert.Equal("wrap[orig<Int32>:5|ValBox(5)]", ValBoxSrc.ValAll<int>(5, new ValBox<int>(5)));
+            Assert.Equal("orig<Int64>:7|ValBox(7)", ValBoxSrc.ValAll<long>(7L, new ValBox<long>(7L)));
+        }
+
+        [GenericHookFact]
+        public void ValueContainerRefKeyNone()
+        {
+            var src = GetMethod(typeof(ValBoxSrc), nameof(ValBoxSrc.RefNone));
+            Assert.True(IsShared(src, typeof(GenBase)));
+
+            using var hook = Hook(src, nameof(ValBoxWrap), AutoPrimeMode.None, [typeof(GenBase)]);
+            Assert.Equal("wrap[orig<GenBase>:B|ValBox(B)]", ValBoxSrc.RefNone<GenBase>(new GenBase(), new ValBox<GenBase>(new GenBase())));
+            Assert.Equal("orig<GenDerived>:D|ValBox(D)", ValBoxSrc.RefNone<GenDerived>(new GenDerived(), new ValBox<GenDerived>(new GenDerived())));
+        }
+
+        [GenericHookFact]
+        public void ValueContainerRefKeyCompatible()
+        {
+            var src = GetMethod(typeof(ValBoxSrc), nameof(ValBoxSrc.RefCompatible));
+            using var hook = Hook(src, nameof(ValBoxWrap), AutoPrimeMode.Compatible, [typeof(GenBase)]);
+
+            Assert.Equal("wrap[orig<GenBase>:B|ValBox(B)]", ValBoxSrc.RefCompatible<GenBase>(new GenBase(), new ValBox<GenBase>(new GenBase())));
+            Assert.Equal("wrap[orig<GenDerived>:D|ValBox(D)]", ValBoxSrc.RefCompatible<GenDerived>(new GenDerived(), new ValBox<GenDerived>(new GenDerived())));
+            Assert.Equal("orig<GenUnrelated>:U|ValBox(U)", ValBoxSrc.RefCompatible<GenUnrelated>(new GenUnrelated(), new ValBox<GenUnrelated>(new GenUnrelated())));
+        }
+
+        [GenericHookFact]
+        public void ValueContainerRefKeyAll()
+        {
+            var src = GetMethod(typeof(ValBoxSrc), nameof(ValBoxSrc.RefAll));
+            using var hook = Hook(src, nameof(ValBoxWrap), AutoPrimeMode.All, [typeof(GenBase)]);
+
+            Assert.Equal("wrap[orig<GenBase>:B|ValBox(B)]", ValBoxSrc.RefAll<GenBase>(new GenBase(), new ValBox<GenBase>(new GenBase())));
+            Assert.Equal("wrap[orig<GenDerived>:D|ValBox(D)]", ValBoxSrc.RefAll<GenDerived>(new GenDerived(), new ValBox<GenDerived>(new GenDerived())));
+            Assert.Equal("wrap[orig<GenUnrelated>:U|ValBox(U)]", ValBoxSrc.RefAll<GenUnrelated>(new GenUnrelated(), new ValBox<GenUnrelated>(new GenUnrelated())));
+        }
+    }
+
+    public sealed class RefBox<K>
+    {
+        public K Value;
+        public RefBox(K value) => Value = value;
+        public override string ToString() => $"RefBox({Value})";
+    }
+
+    public struct ValBox<K>
+    {
+        public K Value;
+        public ValBox(K value) => Value = value;
+        public override string ToString() => $"ValBox({Value})";
+    }
+
+    public static class RefBoxSrc
+    {
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static string ValNone<K>(K par1, RefBox<K> par2) => $"orig<{typeof(K).Name}>:{par1}|{par2}";
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static string ValCompatible<K>(K par1, RefBox<K> par2) => $"orig<{typeof(K).Name}>:{par1}|{par2}";
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static string ValAll<K>(K par1, RefBox<K> par2) => $"orig<{typeof(K).Name}>:{par1}|{par2}";
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static string RefNone<K>(K par1, RefBox<K> par2) => $"orig<{typeof(K).Name}>:{par1}|{par2}";
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static string RefCompatible<K>(K par1, RefBox<K> par2) => $"orig<{typeof(K).Name}>:{par1}|{par2}";
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static string RefAll<K>(K par1, RefBox<K> par2) => $"orig<{typeof(K).Name}>:{par1}|{par2}";
+    }
+
+    public static class ValBoxSrc
+    {
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static string ValNone<K>(K par1, ValBox<K> par2) => $"orig<{typeof(K).Name}>:{par1}|{par2}";
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static string ValCompatible<K>(K par1, ValBox<K> par2) => $"orig<{typeof(K).Name}>:{par1}|{par2}";
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static string ValAll<K>(K par1, ValBox<K> par2) => $"orig<{typeof(K).Name}>:{par1}|{par2}";
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static string RefNone<K>(K par1, ValBox<K> par2) => $"orig<{typeof(K).Name}>:{par1}|{par2}";
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static string RefCompatible<K>(K par1, ValBox<K> par2) => $"orig<{typeof(K).Name}>:{par1}|{par2}";
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static string RefAll<K>(K par1, ValBox<K> par2) => $"orig<{typeof(K).Name}>:{par1}|{par2}";
+    }
+}

--- a/src/MonoMod.UnitTest/RuntimeDetour/Generics/GenericHookInstanceStructReturnTest.cs
+++ b/src/MonoMod.UnitTest/RuntimeDetour/Generics/GenericHookInstanceStructReturnTest.cs
@@ -1,0 +1,60 @@
+extern alias New;
+using New::MonoMod.RuntimeDetour.Generics;
+using System;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace MonoMod.UnitTest.RuntimeDetour.Generics
+{
+    [Collection("RuntimeDetour")]
+    public class GenericHookInstanceStructReturnTest(ITestOutputHelper helper) : GenericTestBase(helper)
+    {
+
+        private static GenericHook Hook(MethodInfo src, string targetName, params Type[][] vectors) => new(src, GetMethod(typeof(GenericHookInstanceStructReturnTest), targetName), vectors);
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        internal static Big MakeBigReplace<T>(InstanceBig self, T value) => new Big(self.Seed + 100, typeof(T).Name.Length);
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        internal static Big MakeBigWrap<T>(Func<InstanceBig, T, Big> orig, InstanceBig self, T value)
+        {
+            var b = orig(self, value);
+            return new Big(b.A + 1000, b.F);
+        }
+
+        [GenericHookFact]
+        public void InstanceStructReturnSharedReplaced()
+        {
+            var src = GetMethod(typeof(InstanceBig), nameof(InstanceBig.Make));
+            Assert.True(IsShared(src, typeof(string)));
+
+            using var hook = Hook(src, nameof(MakeBigReplace), [typeof(string)]);
+
+            var obj = new InstanceBig(5);
+            Assert.Equal(new Big(105, 6), obj.Make<string>("x"));
+        }
+
+        [GenericHookFact]
+        public void InstanceStructReturnSharedWithOrig()
+        {
+            var src = GetMethod(typeof(InstanceBig), nameof(InstanceBig.Make));
+            Assert.True(IsShared(src, typeof(string)));
+
+            using var hook = Hook(src, nameof(MakeBigWrap), [typeof(string)]);
+
+            var obj = new InstanceBig(7);
+            Assert.Equal(new Big(1007, 13), obj.Make<string>("x"));
+        }
+    }
+
+    public class InstanceBig
+    {
+        public long Seed;
+        public InstanceBig(long seed) => Seed = seed;
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public Big Make<T>(T value) => new Big(Seed, Seed + typeof(T).Name.Length);
+    }
+}

--- a/src/MonoMod.UnitTest/RuntimeDetour/Generics/GenericHookOrigIdentityTest.cs
+++ b/src/MonoMod.UnitTest/RuntimeDetour/Generics/GenericHookOrigIdentityTest.cs
@@ -1,0 +1,39 @@
+extern alias New;
+using New::MonoMod.RuntimeDetour.Generics;
+using System;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace MonoMod.UnitTest.RuntimeDetour.Generics
+{
+    [Collection("RuntimeDetour")]
+    public class GenericHookOrigIdentityTest(ITestOutputHelper helper) : GenericTestBase(helper)
+    {
+
+        private static GenericHook Hook(MethodInfo src, string targetName, params Type[][] vectors) => new(src, GetMethod(typeof(GenericHookOrigIdentityTest), targetName), vectors);
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        internal static string DescribeWrap<T>(Func<T> orig) => $"wrap:{typeof(T).Name}:{orig()}";
+
+        [GenericHookFact]
+        public void OrigSeesCorrectTypeIdentityAcrossSharedInstantiations()
+        {
+            var src = GetMethod(typeof(OrigId), nameof(OrigId.Describe));
+            Assert.True(IsShared(src, typeof(string)));
+            Assert.True(IsShared(src, typeof(object)));
+
+            using var hook = Hook(src, nameof(DescribeWrap), [typeof(string)], [typeof(object)]);
+
+            Assert.Equal("wrap:String:String", OrigId.Describe<string>());
+            Assert.Equal("wrap:Object:Object", OrigId.Describe<object>());
+        }
+    }
+
+    public static class OrigId
+    {
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static string Describe<T>() => typeof(T).Name;
+    }
+}

--- a/src/MonoMod.UnitTest/RuntimeDetour/Generics/GenericHookStructVirtualRefTest.cs
+++ b/src/MonoMod.UnitTest/RuntimeDetour/Generics/GenericHookStructVirtualRefTest.cs
@@ -1,0 +1,341 @@
+extern alias New;
+using New::MonoMod.RuntimeDetour.Generics;
+using System;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace MonoMod.UnitTest.RuntimeDetour.Generics
+{
+    [Collection("RuntimeDetour")]
+    public class GenericHookStructVirtualRefTest(ITestOutputHelper helper) : GenericTestBase(helper)
+    {
+
+        private static GenericHook Hook(MethodInfo src, string targetName, params Type[][] vectors) => new(src, GetMethod(typeof(GenericHookStructVirtualRefTest), targetName), vectors);
+
+        private static GenericHook Hook(MethodInfo src, string targetName, AutoPrimeMode mode, params Type[][] vectors) => new(src, GetMethod(typeof(GenericHookStructVirtualRefTest), targetName), vectors, mode);
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        internal static string StructReplace<T>(T value) => $"hook<{typeof(T).Name}>:{value}";
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        internal static string StructWrap<T>(Func<T, string> orig, T value) => $"wrap[{orig(value)}]";
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        internal static T EchoReplace<T>(T value)
+        {
+            if (value is Vec3 v)
+                return (T)(object)new Vec3(v.X + 1, v.Y + 1, v.Z + 1);
+            if (value is Big b)
+                return (T)(object)new Big(b.A + 1, b.F + 1);
+            return value;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        internal static string SGenReplace<T>(ref SGen<T> self) => $"hook<{typeof(T).Name}>:{self.Value}";
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        internal static string SGenWrap<T>(StructThisOrig<T> orig, ref SGen<T> self) => $"wrap[{orig(ref self)}]";
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        internal static string VBaseReplace<T>(VBase self, T value) => $"hookbase<{typeof(T).Name}>:{value}";
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        internal static string VOverrideReplace<T>(VOverride self, T value) => $"hookover<{typeof(T).Name}>:{value}";
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        internal static string VBaseWrap<T>(Func<VBase, T, string> orig, VBase self, T value) => $"wrap[{orig(self, value)}]";
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        internal static string TwoSpeakReplace<T1, T2>(VTwo self, T1 a, T2 b) => $"hook<{typeof(T1).Name},{typeof(T2).Name}>:{a}|{b}";
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        internal static string RefDoubleReplace<T>(ref T value)
+        {
+            if (value is int i)
+                value = (T)(object)(i + 1);
+            else if (value is string s)
+                value = (T)(object)(s + "!");
+            return $"hook<{typeof(T).Name}>:{value}";
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        internal static string RefDoubleWrap<T>(RefFunc<T> orig, ref T value)
+        {
+            var s = orig(ref value);
+            if (value is int i)
+                value = (T)(object)(i + 100);
+            return $"wrap[{s}]";
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        internal static string OutInitReplace<T>(T seed, out T result)
+        {
+            result = seed;
+            if (result is int i)
+                result = (T)(object)(i + 7);
+            return $"hook<{typeof(T).Name}>:{result}";
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        internal static string OutInitWrap<T>(OutFunc<T> orig, T seed, out T result)
+        {
+            var s = orig(seed, out result);
+            if (result is int i)
+                result = (T)(object)(i * 10);
+            return $"wrap[{s}]";
+        }
+
+        [GenericHookFact]
+        public void StructArgUnsharedWithoutOrig()
+        {
+            var src = GetMethod(typeof(SrcStruct), nameof(SrcStruct.Take));
+            Assert.False(IsShared(src, typeof(Vec3)));
+
+            using var hook = Hook(src, nameof(StructReplace), [typeof(Vec3)]);
+            Assert.Equal("hook<Vec3>:(1,2,3)", SrcStruct.Take<Vec3>(new Vec3(1, 2, 3)));
+        }
+
+        [GenericHookFact]
+        public void StructArgUnsharedWithOrig()
+        {
+            var src = GetMethod(typeof(SrcStruct), nameof(SrcStruct.Take));
+
+            using var hook = Hook(src, nameof(StructWrap), [typeof(Vec3)]);
+            Assert.Equal("wrap[orig<Vec3>:(1,2,3)]", SrcStruct.Take<Vec3>(new Vec3(1, 2, 3)));
+        }
+
+        [GenericHookFact]
+        public void SmallStructReturnReplaced()
+        {
+            var src = GetMethod(typeof(SrcStruct), nameof(SrcStruct.Echo));
+            using var hook = Hook(src, nameof(EchoReplace), [typeof(Vec3)]);
+
+            Assert.Equal(new Vec3(2, 3, 4), SrcStruct.Echo<Vec3>(new Vec3(1, 2, 3)));
+        }
+
+        [GenericHookFact]
+        public void LargeStructReturnReplaced()
+        {
+            var src = GetMethod(typeof(SrcStruct), nameof(SrcStruct.Echo));
+            using var hook = Hook(src, nameof(EchoReplace), [typeof(Big)]);
+
+            Assert.Equal(new Big(11, 61), SrcStruct.Echo<Big>(new Big(10, 60)));
+        }
+
+        [GenericHookFact]
+        public void StructThisUnsharedWithoutOrig()
+        {
+            var src = GetMethod(typeof(SGen<>), nameof(SGen<object>.Describe));
+            using var hook = Hook(src, nameof(SGenReplace), [typeof(int)]);
+
+            var s = new SGen<int>(5);
+            Assert.Equal("hook<Int32>:5", s.Describe());
+        }
+
+        [GenericHookFact]
+        public void StructThisWithOrig()
+        {
+            var src = GetMethod(typeof(SGen<>), nameof(SGen<object>.Describe));
+            using var hook = Hook(src, nameof(SGenWrap), [typeof(int)]);
+
+            var s = new SGen<int>(9);
+            Assert.Equal("wrap[orig<Int32>:9]", s.Describe());
+        }
+
+        [GenericHookFact]
+        public void VirtualBaseHookDoesNotCatchOverride()
+        {
+            var src = GetMethod(typeof(VBase), nameof(VBase.Speak));
+            using var hook = Hook(src, nameof(VBaseReplace), [typeof(int)]);
+
+            Assert.Equal("hookbase<Int32>:5", new VBase().Speak<int>(5));
+            Assert.Equal("hookbase<Int32>:5", new VInherit().Speak<int>(5));
+            Assert.Equal("over<Int32>:5", new VOverride().Speak<int>(5));
+        }
+
+        [GenericHookFact]
+        public void OverrideHookDoesNotCatchBase()
+        {
+            var src = GetMethod(typeof(VOverride), nameof(VOverride.Speak));
+            using var hook = Hook(src, nameof(VOverrideReplace), [typeof(int)]);
+
+            Assert.Equal("hookover<Int32>:5", new VOverride().Speak<int>(5));
+            Assert.Equal("base<Int32>:5", new VBase().Speak<int>(5));
+        }
+
+        [GenericHookFact]
+        public void OverrideHookCaughtThroughVirtualDispatch()
+        {
+            var src = GetMethod(typeof(VOverride), nameof(VOverride.Speak));
+            using var hook = Hook(src, nameof(VOverrideReplace), [typeof(int)]);
+
+            VBase v = new VOverride();
+            Assert.Equal("hookover<Int32>:5", v.Speak<int>(5));
+        }
+
+        [GenericHookFact]
+        public void VirtualBaseHookSharedWithOrig()
+        {
+            var src = GetMethod(typeof(VBase), nameof(VBase.Speak));
+            Assert.True(IsShared(src, typeof(string)));
+
+            using var hook = Hook(src, nameof(VBaseWrap), [typeof(string)]);
+            Assert.Equal("wrap[base<String>:hi]", new VBase().Speak<string>("hi"));
+        }
+
+        [GenericHookFact]
+        public void VirtualMixedKeyValueTypeAutoDiscovery()
+        {
+            var src = GetMethod(typeof(VTwo), nameof(VTwo.TwoSpeak));
+            using var hook = Hook(src, nameof(TwoSpeakReplace), AutoPrimeMode.Compatible, [typeof(GenBase), typeof(int)]);
+
+            Assert.Equal("hook<GenBase,Int32>:B|5", new VTwo().TwoSpeak<GenBase, int>(new GenBase(), 5));
+
+            var derived = new VTwo().TwoSpeak<GenDerived, int>(new GenDerived(), 5);
+            Assert.Equal(
+                GenericHook.SupportsValueTypeAutoPrime ? "hook<GenDerived,Int32>:D|5" : "orig<GenDerived,Int32>:D|5",
+                derived);
+        }
+
+        [GenericHookFact]
+        public void RefArgUnsharedWithoutOrig()
+        {
+            var src = GetMethod(typeof(SrcRef), nameof(SrcRef.RefDouble));
+            Assert.False(IsShared(src, typeof(int)));
+
+            using var hook = Hook(src, nameof(RefDoubleReplace), [typeof(int)]);
+            var x = 5;
+            Assert.Equal("hook<Int32>:6", SrcRef.RefDouble<int>(ref x));
+            Assert.Equal(6, x);
+        }
+
+        [GenericHookFact]
+        public void RefArgUnsharedWithOrig()
+        {
+            var src = GetMethod(typeof(SrcRef), nameof(SrcRef.RefDouble));
+
+            using var hook = Hook(src, nameof(RefDoubleWrap), [typeof(int)]);
+            var x = 5;
+            Assert.Equal("wrap[orig<Int32>:10]", SrcRef.RefDouble<int>(ref x));
+            Assert.Equal(110, x);
+        }
+
+        [GenericHookFact]
+        public void RefArgSharedWithoutOrig()
+        {
+            var src = GetMethod(typeof(SrcRef), nameof(SrcRef.RefDouble));
+            Assert.True(IsShared(src, typeof(string)));
+
+            using var hook = Hook(src, nameof(RefDoubleReplace), [typeof(string)]);
+            var s = "hi";
+            Assert.Equal("hook<String>:hi!", SrcRef.RefDouble<string>(ref s));
+            Assert.Equal("hi!", s);
+        }
+
+        [GenericHookFact]
+        public void OutArgUnsharedWithoutOrig()
+        {
+            var src = GetMethod(typeof(SrcRef), nameof(SrcRef.OutInit));
+            Assert.False(IsShared(src, typeof(int)));
+
+            using var hook = Hook(src, nameof(OutInitReplace), [typeof(int)]);
+            Assert.Equal("hook<Int32>:12", SrcRef.OutInit<int>(5, out var r));
+            Assert.Equal(12, r);
+        }
+
+        [GenericHookFact]
+        public void OutArgUnsharedWithOrig()
+        {
+            var src = GetMethod(typeof(SrcRef), nameof(SrcRef.OutInit));
+
+            using var hook = Hook(src, nameof(OutInitWrap), [typeof(int)]);
+            Assert.Equal("wrap[orig<Int32>:3]", SrcRef.OutInit<int>(3, out var r));
+            Assert.Equal(30, r);
+        }
+    }
+
+    public delegate string RefFunc<T>(ref T value);
+    public delegate string OutFunc<T>(T seed, out T result);
+    public delegate string StructThisOrig<T>(ref SGen<T> self);
+
+    public struct Vec3
+    {
+        public int X;
+        public int Y;
+        public int Z;
+        public Vec3(int x, int y, int z) { X = x; Y = y; Z = z; }
+        public override string ToString() => $"({X},{Y},{Z})";
+    }
+
+    public struct Big
+    {
+        public long A;
+        public long B;
+        public long C;
+        public long D;
+        public long E;
+        public long F;
+        public Big(long a, long f) { A = a; B = 0; C = 0; D = 0; E = 0; F = f; }
+        public override string ToString() => $"[{A}..{F}]";
+    }
+
+    public struct SGen<T>
+    {
+        public T Value;
+        public SGen(T value) => Value = value;
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public string Describe() => $"orig<{typeof(T).Name}>:{Value}";
+    }
+
+    public static class SrcStruct
+    {
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static string Take<T>(T value) => $"orig<{typeof(T).Name}>:{value}";
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static T Echo<T>(T value) => value;
+    }
+
+    public class VBase
+    {
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public virtual string Speak<T>(T value) => $"base<{typeof(T).Name}>:{value}";
+    }
+
+    public class VOverride : VBase
+    {
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public override string Speak<T>(T value) => $"over<{typeof(T).Name}>:{value}";
+    }
+
+    public class VInherit : VBase
+    {
+    }
+
+    public class VTwo
+    {
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public virtual string TwoSpeak<T1, T2>(T1 a, T2 b) => $"orig<{typeof(T1).Name},{typeof(T2).Name}>:{a}|{b}";
+    }
+
+    public static class SrcRef
+    {
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static string RefDouble<T>(ref T value)
+        {
+            if (value is int i)
+                value = (T)(object)(i * 2);
+            return $"orig<{typeof(T).Name}>:{value}";
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static string OutInit<T>(T seed, out T result)
+        {
+            result = seed;
+            return $"orig<{typeof(T).Name}>:{result}";
+        }
+    }
+}

--- a/src/MonoMod.UnitTest/RuntimeDetour/Generics/GenericHookTest.cs
+++ b/src/MonoMod.UnitTest/RuntimeDetour/Generics/GenericHookTest.cs
@@ -1,0 +1,454 @@
+extern alias New;
+using New::MonoMod.RuntimeDetour.Generics;
+using System;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace MonoMod.UnitTest.RuntimeDetour.Generics
+{
+    [Collection("RuntimeDetour")]
+    public class GenericHookTest(ITestOutputHelper helper) : GenericTestBase(helper)
+    {
+
+        private static GenericHook Hook(MethodInfo src, string targetName, params Type[][] vectors) => new(src, GetMethod(typeof(GenericHookTest), targetName), vectors);
+
+        private static GenericHook Hook(MethodInfo src, string targetName, AutoPrimeMode mode, params Type[][] vectors) => new(src, GetMethod(typeof(GenericHookTest), targetName), vectors, mode);
+
+        private static bool ValueTypeAutoPrimeSupported => GenericHook.SupportsValueTypeAutoPrime;
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        internal static string Replace<T>(T value) => $"hook<{typeof(T).Name}>:{value}";
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        internal static string WrapF<T>(Func<T, string> orig, T value) => $"wrap[{orig(value)}]";
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        internal static string AorigF<T>(Func<T, string> orig, T value) => $"A({orig(value)})";
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        internal static string BorigF<T>(Func<T, string> orig, T value) => $"B({orig(value)})";
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        internal static string CorigF<T>(Func<T, string> orig, T value) => $"C({orig(value)})";
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        internal static string KeyA<T>(T value) => $"A:{value}";
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        internal static string KeyB<T>(T value) => $"B:{value}";
+        
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        internal static string TwoReplace<T1, T2>(T1 a, T2 b) => $"hook<{typeof(T1).Name},{typeof(T2).Name}>:{a}|{b}";
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        internal static string TwoWrap<T1, T2>(Func<T1, T2, string> orig, T1 a, T2 b) => $"wrap[{orig(a, b)}]";
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        internal static string InstReplace<T>(InstGM self, T value) => $"hook<{typeof(T).Name}>:{self.Tag}:{value}";
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        internal static string InstWrap<T>(Func<InstGM, T, string> orig, InstGM self, T value) => $"wrap[{orig(self, value)}]";
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        internal static string GciReplace<T>(GcInst<T> self) => $"hook<{typeof(T).Name}>:{self.Value}";
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        internal static string GciWrap<T>(Func<GcInst<T>, string> orig, GcInst<T> self) => $"wrap[{orig(self)}]";
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        internal static string GcgmReplace<TC, TM>(GcGm<TC> self, TM second) => $"hook<{typeof(TC).Name},{typeof(TM).Name}>:{self.First}+{second}";
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        internal static string GcgmWrap<TC, TM>(Func<GcGm<TC>, TM, string> orig, GcGm<TC> self, TM second) => $"wrap[{orig(self, second)}]";
+
+        [GenericHookFact]
+        public void UnsharedWithOrig()
+        {
+            var src = GetMethod(typeof(Src), nameof(Src.UnsharedOrig));
+            Assert.False(IsShared(src, typeof(int)));
+
+            Assert.Equal("orig<Int32>:5", Src.UnsharedOrig<int>(5));
+            using var hook = Hook(src, nameof(WrapF), [typeof(int)]);
+            Assert.Equal("wrap[orig<Int32>:5]", Src.UnsharedOrig<int>(5));
+        }
+
+        [GenericHookFact]
+        public void UnsharedWithoutOrig()
+        {
+            var src = GetMethod(typeof(Src), nameof(Src.UnsharedNoOrig));
+            Assert.False(IsShared(src, typeof(int)));
+
+            Assert.Equal("orig<Int32>:5", Src.UnsharedNoOrig<int>(5));
+            using var hook = Hook(src, nameof(Replace), [typeof(int)]);
+            Assert.Equal("hook<Int32>:5", Src.UnsharedNoOrig<int>(5));
+        }
+
+        [GenericHookFact]
+        public void SharedWithOrig()
+        {
+            var src = GetMethod(typeof(Src), nameof(Src.SharedOrig));
+            Assert.True(IsShared(src, typeof(string)));
+
+            Assert.Equal("orig<String>:hi", Src.SharedOrig<string>("hi"));
+            using var hook = Hook(src, nameof(WrapF), [typeof(string)]);
+            Assert.Equal("wrap[orig<String>:hi]", Src.SharedOrig<string>("hi"));
+        }
+
+        [GenericHookFact]
+        public void SharedWithoutOrig()
+        {
+            var src = GetMethod(typeof(Src), nameof(Src.SharedNoOrig));
+            Assert.True(IsShared(src, typeof(string)));
+
+            Assert.Equal("orig<String>:hi", Src.SharedNoOrig<string>("hi"));
+            using var hook = Hook(src, nameof(Replace), [typeof(string)]);
+            Assert.Equal("hook<String>:hi", Src.SharedNoOrig<string>("hi"));
+        }
+
+        [GenericHookFact]
+        public void SharedAndUnsharedOnSameHook()
+        {
+            var src = GetMethod(typeof(Src), nameof(Src.Both));
+            using var hook = Hook(src, nameof(Replace), [typeof(int)], [typeof(string)]);
+
+            Assert.Equal("hook<Int32>:7", Src.Both<int>(7));
+            Assert.Equal("hook<String>:hi", Src.Both<string>("hi"));
+        }
+
+        [GenericHookFact]
+        public void ChainingSameKeyUnshared()
+        {
+            var src = GetMethod(typeof(Src), nameof(Src.ChainSameUnshared));
+            using var a = Hook(src, nameof(AorigF), [typeof(int)]);
+            using var b = Hook(src, nameof(BorigF), [typeof(int)]);
+
+            Assert.Equal("B(A(orig<Int32>:9))", Src.ChainSameUnshared<int>(9));
+        }
+
+        [GenericHookFact]
+        public void ChainingDifferentKeysUnshared()
+        {
+            var src = GetMethod(typeof(Src), nameof(Src.ChainDiffUnshared));
+            using var hi = Hook(src, nameof(KeyA), [typeof(int)]);
+            using var hl = Hook(src, nameof(KeyB), [typeof(long)]);
+
+            Assert.Equal("A:3", Src.ChainDiffUnshared<int>(3));
+            Assert.Equal("B:2", Src.ChainDiffUnshared<long>(2L));
+        }
+
+        [GenericHookFact]
+        public void ChainingDifferentKeysShared()
+        {
+            var src = GetMethod(typeof(Src), nameof(Src.ChainDiffShared));
+            using var hs = Hook(src, nameof(KeyA), [typeof(string)]);
+            using var ho = Hook(src, nameof(KeyB), [typeof(object)]);
+
+            Assert.Equal("A:s", Src.ChainDiffShared<string>("s"));
+            Assert.Equal("B:42", Src.ChainDiffShared<object>(42));
+            Assert.Equal("orig<GenBase>:B", Src.ChainDiffShared<GenBase>(new GenBase()));
+        }
+
+        [GenericHookFact]
+        public void ChainingSameKeyShared()
+        {
+            var src = GetMethod(typeof(Src), nameof(Src.ChainSameShared));
+            using var a = Hook(src, nameof(AorigF), [typeof(string)]);
+            using var b = Hook(src, nameof(BorigF), [typeof(string)]);
+
+            Assert.Equal("B(A(orig<String>:z))", Src.ChainSameShared<string>("z"));
+        }
+
+        [GenericHookFact]
+        public void ChainingSameKeySharedThreeHooks()
+        {
+            var src = GetMethod(typeof(Src), nameof(Src.ChainTripleShared));
+            using var a = Hook(src, nameof(AorigF), [typeof(string)]);
+            using var b = Hook(src, nameof(BorigF), [typeof(string)]);
+            using var c = Hook(src, nameof(CorigF), [typeof(string)]);
+
+            Assert.Equal("C(B(A(orig<String>:z)))", Src.ChainTripleShared<string>("z"));
+        }
+
+        [GenericHookFact]
+        public void ChainingSameKeySharedDisposeMiddleRefolds()
+        {
+            var src = GetMethod(typeof(Src), nameof(Src.ChainDisposeMiddleShared));
+            using var a = Hook(src, nameof(AorigF), [typeof(string)]);
+            var b = Hook(src, nameof(BorigF), [typeof(string)]);
+            using var c = Hook(src, nameof(CorigF), [typeof(string)]);
+
+            Assert.Equal("C(B(A(orig<String>:z)))", Src.ChainDisposeMiddleShared<string>("z"));
+
+            b.Dispose();
+            Assert.Equal("C(A(orig<String>:z))", Src.ChainDisposeMiddleShared<string>("z"));
+        }
+
+        [GenericHookFact]
+        public void TwoGenericSameAllValue()
+        {
+            var src = GetMethod(typeof(SrcTwo), nameof(SrcTwo.SameValue));
+            Assert.False(IsShared(src, typeof(int), typeof(long)));
+
+            using var hook = Hook(src, nameof(TwoReplace), [typeof(int), typeof(long)]);
+            Assert.Equal("hook<Int32,Int64>:1|2", SrcTwo.SameValue<int, long>(1, 2L));
+        }
+
+        [GenericHookFact]
+        public void TwoGenericSameAllReference()
+        {
+            var src = GetMethod(typeof(SrcTwo), nameof(SrcTwo.SameRef));
+            Assert.True(IsShared(src, typeof(string), typeof(object)));
+
+            using var hook = Hook(src, nameof(TwoReplace), [typeof(string), typeof(object)]);
+            Assert.Equal("hook<String,Object>:a|z", SrcTwo.SameRef<string, object>("a", "z"));
+        }
+
+        [GenericHookFact]
+        public void TwoGenericMixedValueReference()
+        {
+            var src = GetMethod(typeof(SrcTwo), nameof(SrcTwo.Mixed));
+            Assert.True(IsShared(src, typeof(int), typeof(string)));
+            Assert.True(IsShared(src, typeof(string), typeof(int)));
+
+            using var hook = Hook(src, nameof(TwoReplace), 
+                [typeof(int), typeof(string)], [typeof(string), typeof(int)],
+                [typeof(long), typeof(object)], [typeof(object), typeof(long)]);
+
+            Assert.Equal("hook<Int32,String>:5|x", SrcTwo.Mixed<int, string>(5, "x"));
+            Assert.Equal("hook<String,Int32>:x|5", SrcTwo.Mixed<string, int>("x", 5));
+            Assert.Equal("hook<Int64,Object>:7|o", SrcTwo.Mixed<long, object>(7L, "o"));
+            Assert.Equal("hook<Object,Int64>:o|7", SrcTwo.Mixed<object, long>("o", 7L));
+        }
+
+        [GenericHookFact]
+        public void InstanceGenericMethodUnsharedWithOrig()
+        {
+            var src = GetMethod(typeof(InstGM), nameof(InstGM.Wrap));
+            using var hook = Hook(src, nameof(InstWrap), [typeof(int)]);
+
+            Assert.Equal("wrap[orig<Int32>:H:5]", new InstGM("H").Wrap<int>(5));
+        }
+
+        [GenericHookFact]
+        public void InstanceGenericMethodSharedWithoutOrig()
+        {
+            var src = GetMethod(typeof(InstGM), nameof(InstGM.Wrap));
+            Assert.True(IsShared(src, typeof(string)));
+
+            using var hook = Hook(src, nameof(InstReplace), [typeof(string)]);
+            Assert.Equal("hook<String>:H:x", new InstGM("H").Wrap<string>("x"));
+        }
+
+        [GenericHookFact]
+        public void GenericClassInstanceThisObjectUnshared()
+        {
+            var src = GetMethod(typeof(GcInst<>), nameof(GcInst<object>.Describe));
+            using var hook = Hook(src, nameof(GciReplace), [typeof(int)]);
+
+            Assert.Equal("hook<Int32>:5", new GcInst<int>(5).Describe());
+        }
+
+        [GenericHookFact]
+        public void GenericClassInstanceThisObjectSharedWithOrig()
+        {
+            var src = GetMethod(typeof(GcInst<>), nameof(GcInst<object>.Describe));
+            using var hook = Hook(src, nameof(GciWrap), [typeof(string)]);
+
+            Assert.Equal("wrap[orig<String>:x]", new GcInst<string>("x").Describe());
+        }
+
+        [GenericHookFact]
+        public void GenericClassStaticMethodTableUnshared()
+        {
+            var src = GetMethod(typeof(GcStat<>), nameof(GcStat<object>.Make));
+            using var hook = Hook(src, nameof(Replace), [typeof(int)]);
+
+            Assert.Equal("hook<Int32>:5", GcStat<int>.Make(5));
+        }
+
+        [GenericHookFact]
+        public void GenericClassStaticMethodTableSharedWithOrig()
+        {
+            var src = GetMethod(typeof(GcStat<>), nameof(GcStat<object>.Make));
+            using var hook = Hook(src, nameof(WrapF), [typeof(string)]);
+
+            Assert.Equal("wrap[orig<String>:x]", GcStat<string>.Make("x"));
+        }
+
+        [GenericHookFact]
+        public void GenericClassGenericMethodMixed()
+        {
+            var src = GetMethod(typeof(GcGm<>), nameof(GcGm<object>.Combine));
+            var src1 = GetMethod(typeof(GcGm<string>), nameof(GcGm<object>.Combine));
+            var src2 = GetMethod(typeof(GcGm<int>), nameof(GcGm<object>.Combine));
+            var src3 = GetMethod(typeof(GcGm<int>), nameof(GcGm<object>.Combine));
+            Assert.True(IsShared(src1, typeof(int)));
+            Assert.False(IsShared(src2, typeof(long)));
+            Assert.True(IsShared(src3, typeof(string)));
+
+            using var hook = Hook(src, nameof(GcgmReplace),
+                [typeof(string), typeof(int)],
+                [typeof(int), typeof(long)],
+                [typeof(int), typeof(string)]);
+
+            Assert.Equal("hook<String,Int32>:F+5", new GcGm<string>("F").Combine<int>(5));
+            Assert.Equal("hook<Int32,Int64>:1+2", new GcGm<int>(1).Combine<long>(2L));
+            Assert.Equal("hook<Int32,String>:1+x", new GcGm<int>(1).Combine<string>("x"));
+        }
+
+        [GenericHookFact]
+        public void CatchNoneDoesNotCatchDerived()
+        {
+            var src = GetMethod(typeof(Src), nameof(Src.CatchNone));
+            using var hook = Hook(src, nameof(Replace), AutoPrimeMode.None, [typeof(GenBase)]);
+
+            Assert.Equal("hook<GenBase>:B", Src.CatchNone<GenBase>(new GenBase()));
+            Assert.Equal("orig<GenDerived>:D", Src.CatchNone<GenDerived>(new GenDerived()));
+        }
+
+        [GenericHookFact]
+        public void CatchAllAutoPrimesDerivedAsOwnKey()
+        {
+            var src = GetMethod(typeof(Src), nameof(Src.CatchAll));
+            using var hook = Hook(src, nameof(Replace), AutoPrimeMode.All, [typeof(GenBase)]);
+
+            Assert.Equal("hook<GenBase>:B", Src.CatchAll<GenBase>(new GenBase()));
+            Assert.Equal("hook<GenDerived>:D", Src.CatchAll<GenDerived>(new GenDerived()));
+        }
+
+        [GenericHookFact]
+        public void CatchCompatibleBaseEntryCatchesDerived()
+        {
+            var src = GetMethod(typeof(Src), nameof(Src.CatchCompatible));
+            using var hook = Hook(src, nameof(Replace), AutoPrimeMode.Compatible, [typeof(GenBase)]);
+
+            Assert.Equal("hook<GenBase>:B", Src.CatchCompatible<GenBase>(new GenBase()));
+            Assert.Equal("hook<GenDerived>:D", Src.CatchCompatible<GenDerived>(new GenDerived()));
+        }
+
+        [GenericHookFact]
+        public void CatchCompatibleUnrelatedNotCaught()
+        {
+            var src = GetMethod(typeof(Src), nameof(Src.CatchCompatibleUnrelated));
+            using var hook = Hook(src, nameof(Replace), AutoPrimeMode.Compatible, [typeof(GenBase)]);
+
+            Assert.Equal("orig<GenUnrelated>:U", Src.CatchCompatibleUnrelated<GenUnrelated>(new GenUnrelated()));
+        }
+
+        [GenericHookFact]
+        public void MixedKeyAllAutoDiscoversReferencePosition()
+        {
+            var src = GetMethod(typeof(SrcTwo), nameof(SrcTwo.CompatPerPosition));
+            using var hook = Hook(src, nameof(TwoReplace), AutoPrimeMode.All, [typeof(GenBase), typeof(int)]);
+
+            Assert.Equal("hook<GenBase,Int32>:B|5", SrcTwo.CompatPerPosition<GenBase, int>(new GenBase(), 5));
+
+            var derived = SrcTwo.CompatPerPosition<GenDerived, int>(new GenDerived(), 5);
+            Assert.Equal(
+                ValueTypeAutoPrimeSupported ? "hook<GenDerived,Int32>:D|5" : "orig<GenDerived,Int32>:D|5",
+                derived);
+
+            Assert.Equal("orig<GenBase,Int64>:B|7", SrcTwo.CompatPerPosition<GenBase, long>(new GenBase(), 7L));
+        }
+
+        [GenericHookFact]
+        public void MixedKeyCompatibleAutoDiscoversAssignableReference()
+        {
+            var src = GetMethod(typeof(SrcTwo), nameof(SrcTwo.CompatPerPosition));
+            using var hook = Hook(src, nameof(TwoReplace), AutoPrimeMode.Compatible, [typeof(GenBase), typeof(int)]);
+
+            Assert.Equal("hook<GenBase,Int32>:B|5", SrcTwo.CompatPerPosition<GenBase, int>(new GenBase(), 5));
+
+            var derived = SrcTwo.CompatPerPosition<GenDerived, int>(new GenDerived(), 5);
+            Assert.Equal(
+                ValueTypeAutoPrimeSupported ? "hook<GenDerived,Int32>:D|5" : "orig<GenDerived,Int32>:D|5",
+                derived);
+
+            Assert.Equal("orig<GenUnrelated,Int32>:U|5", SrcTwo.CompatPerPosition<GenUnrelated, int>(new GenUnrelated(), 5));
+        }
+
+        [GenericHookFact]
+        public void ValueTypeInstantiationIsCaughtWhenExplicitlyPrimed()
+        {
+            var src = GetMethod(typeof(SrcTwo), nameof(SrcTwo.CompatPerPosition));
+            using var hook = Hook(src, nameof(TwoReplace), [typeof(GenDerived), typeof(long)]);
+
+            Assert.Equal("hook<GenDerived,Int64>:D|7", SrcTwo.CompatPerPosition<GenDerived, long>(new GenDerived(), 7L));
+        }
+
+        [GenericHookFact]
+        public void PrimeAfterConstructionUnshared()
+        {
+            var src = GetMethod(typeof(Src), nameof(Src.PrimeAfterUnshared));
+            using var hook = new GenericHook(src, GetMethod(typeof(GenericHookTest), nameof(Replace)));
+
+            Assert.Equal("orig<Int32>:5", Src.PrimeAfterUnshared<int>(5));
+            hook.Prime(typeof(int));
+            Assert.Equal("hook<Int32>:5", Src.PrimeAfterUnshared<int>(5));
+        }
+
+        [GenericHookFact]
+        public void PrimeAfterConstructionShared()
+        {
+            var src = GetMethod(typeof(Src), nameof(Src.PrimeAfterShared));
+            using var hook = new GenericHook(src, GetMethod(typeof(GenericHookTest), nameof(Replace)));
+
+            Assert.Equal("orig<String>:x", Src.PrimeAfterShared<string>("x"));
+            hook.Prime(typeof(string));
+            Assert.Equal("hook<String>:x", Src.PrimeAfterShared<string>("x"));
+        }
+
+        [GenericHookFact]
+        public void PrimeConstructorPrimesListedKeysOnlyAndIsIdempotent()
+        {
+            var src = GetMethod(typeof(Src), nameof(Src.DoublePrime));
+            using var hook = Hook(src, nameof(Replace), [typeof(int)]);
+
+            hook.Prime(typeof(int));
+            Assert.Equal("hook<Int32>:5", Src.DoublePrime<int>(5));
+            Assert.Equal("orig<Int64>:5", Src.DoublePrime<long>(5L));
+        }
+
+        [GenericHookFact]
+        public void DisposeRestoresOriginalUnshared()
+        {
+            var src = GetMethod(typeof(Src), nameof(Src.DisposeUnshared));
+            var hook = Hook(src, nameof(Replace), [typeof(int)]);
+
+            Assert.Equal("hook<Int32>:5", Src.DisposeUnshared<int>(5));
+            hook.Dispose();
+            Assert.Equal("orig<Int32>:5", Src.DisposeUnshared<int>(5));
+        }
+
+        [GenericHookFact]
+        public void DisposeRestoresOriginalShared()
+        {
+            var src = GetMethod(typeof(Src), nameof(Src.DisposeShared));
+            var hook = Hook(src, nameof(Replace), [typeof(string)]);
+
+            Assert.Equal("hook<String>:x", Src.DisposeShared<string>("x"));
+            hook.Dispose();
+            Assert.Equal("orig<String>:x", Src.DisposeShared<string>("x"));
+        }
+
+        [GenericHookFact]
+        public void CtorRejectsClosedSource()
+        {
+            var closed = GetMethod(typeof(Src), nameof(Src.GenericHookCtor)).MakeGenericMethod(typeof(int));
+            Assert.Throws<ArgumentException>(() => new GenericHook(closed, GetMethod(typeof(GenericHookTest), nameof(Replace))));
+        }
+
+        [GenericHookFact]
+        public void CtorRejectsNullSource()
+        {
+            Assert.Throws<ArgumentNullException>(() => new GenericHook(null!, GetMethod(typeof(GenericHookTest), nameof(Replace))));
+        }
+
+        [GenericHookFact]
+        public void CtorRejectsNullTarget()
+        {
+            Assert.Throws<ArgumentNullException>(() => new GenericHook(GetMethod(typeof(Src), nameof(Src.GenericHookCtor)), null!));
+        }
+    }
+}

--- a/src/MonoMod.UnitTest/RuntimeDetour/Generics/GenericSharingTest.cs
+++ b/src/MonoMod.UnitTest/RuntimeDetour/Generics/GenericSharingTest.cs
@@ -1,0 +1,154 @@
+extern alias New;
+using New::MonoMod.RuntimeDetour.Generics;
+using System;
+using System.Collections.Generic;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace MonoMod.UnitTest.RuntimeDetour.Generics
+{
+    public class GenericSharingTest(ITestOutputHelper helper) : GenericTestBase(helper)
+    {
+
+        #region TypeIsShared
+        [Fact]
+        public void TypeIsSharedPrimitiveIsNotShared()
+        {
+            Assert.False(GenericHelper.TypeIsShared(typeof(int)));
+        }
+
+        [Fact]
+        public void TypeIsSharedNonGenericValueTypeIsNotShared()
+        {
+            Assert.False(GenericHelper.TypeIsShared(typeof(DateTime)));
+        }
+
+        [Fact]
+        public void TypeIsSharedReferenceTypeIsShared()
+        {
+            Assert.True(GenericHelper.TypeIsShared(typeof(string)));
+            Assert.True(GenericHelper.TypeIsShared(typeof(object)));
+            Assert.True(GenericHelper.TypeIsShared(typeof(GenBase)));
+        }
+
+        [Fact]
+        public void TypeIsSharedValueGenericWithReferenceArgIsShared()
+        {
+            Assert.True(GenericHelper.TypeIsShared(typeof(KeyValuePair<int, string>)));
+        }
+
+        [Fact]
+        public void TypeIsSharedValueGenericWithAllValueArgsIsNotShared()
+        {
+            Assert.False(GenericHelper.TypeIsShared(typeof(KeyValuePair<int, long>)));
+            Assert.False(GenericHelper.TypeIsShared(typeof(int?)));
+        }
+
+        [Fact]
+        public void TypeIsSharedOpenGenericThrows()
+        {
+            Assert.Throws<InvalidOperationException>(() => GenericHelper.TypeIsShared(typeof(List<>)));
+        }
+
+        [Fact]
+        public void TypeIsSharedNullThrows()
+        {
+            Assert.Throws<ArgumentNullException>(() => GenericHelper.TypeIsShared(null!));
+        }
+        #endregion
+
+        #region MethodIsShared
+        [Fact]
+        public void MethodIsSharedNonGenericMethodOnNonGenericTypeIsNotShared()
+        {
+            Assert.False(GenericHelper.MethodIsShared(GetMethod(typeof(object), nameof(ToString))));
+        }
+
+        [Fact]
+        public void MethodIsSharedGenericMethodDependsOnMethodArg()
+        {
+            var open = GetMethod(typeof(Src), nameof(Src.GenericHookCtor));
+            Assert.False(GenericHelper.MethodIsShared(open.MakeGenericMethod(typeof(int))));
+            Assert.True(GenericHelper.MethodIsShared(open.MakeGenericMethod(typeof(string))));
+        }
+
+        [Fact]
+        public void MethodIsSharedMethodOnGenericTypeDependsOnTypeArg()
+        {
+            Assert.False(GenericHelper.MethodIsShared(typeof(List<int>).GetMethod(nameof(List<int>.Add))!));
+            Assert.True(GenericHelper.MethodIsShared(typeof(List<string>).GetMethod(nameof(List<string>.Add))!));
+
+            Assert.False(GenericHelper.MethodIsShared(typeof(GcInst<int>).GetMethod(nameof(GcInst<int>.Describe))!));
+            Assert.True(GenericHelper.MethodIsShared(typeof(GcInst<string>).GetMethod(nameof(GcInst<string>.Describe))!));
+        }
+
+        [Fact]
+        public void MethodIsSharedTwoParamGenericMethodSharedIfAnyArgIsReference()
+        {
+            var open = GetMethod(typeof(SrcTwo), nameof(SrcTwo.SameValue));
+            Assert.False(GenericHelper.MethodIsShared(open.MakeGenericMethod(typeof(int), typeof(long))));
+            Assert.True(GenericHelper.MethodIsShared(open.MakeGenericMethod(typeof(int), typeof(string))));
+            Assert.True(GenericHelper.MethodIsShared(open.MakeGenericMethod(typeof(string), typeof(int))));
+        }
+
+        [Fact]
+        public void MethodIsSharedNullThrows()
+        {
+            Assert.Throws<ArgumentNullException>(() => GenericHelper.MethodIsShared(null!));
+        }
+        #endregion
+
+        #region InstantiationKey
+        private static InstantiationKey Key(params Type[] args) => new(args);
+
+        [Fact]
+        public void InstantiationKeyEqualityByContent()
+        {
+            var a = Key(typeof(int), typeof(string));
+            var b = Key(typeof(int), typeof(string));
+            var c = Key(typeof(string), typeof(int));
+
+            Assert.True(a.Equals(b));
+            Assert.True(a == b);
+            Assert.False(a != b);
+            Assert.Equal(a.GetHashCode(), b.GetHashCode());
+
+            Assert.False(a == c);
+            Assert.True(a != c);
+        }
+
+        [Fact]
+        public void InstantiationKeyEqualityLengthMismatch()
+        {
+            Assert.False(Key(typeof(int)).Equals(Key(typeof(int), typeof(string))));
+        }
+
+        [Fact]
+        public void InstantiationKeyToString()
+        {
+            Assert.Equal("<Int32,String>", Key(typeof(int), typeof(string)).ToString());
+        }
+
+        [Fact]
+        public void InstantiationKeyMatchesAssignableFrom()
+        {
+            Assert.True(InstantiationKey.Matches(Key(typeof(GenBase)), Key(typeof(GenBase))));
+            Assert.True(InstantiationKey.Matches(Key(typeof(GenBase)), Key(typeof(GenDerived))));
+            Assert.False(InstantiationKey.Matches(Key(typeof(GenBase)), Key(typeof(GenUnrelated))));
+        }
+
+        [Fact]
+        public void InstantiationKeyMatchesLengthMismatch()
+        {
+            Assert.False(InstantiationKey.Matches(Key(typeof(GenBase)), Key(typeof(GenBase), typeof(int))));
+        }
+
+        [Fact]
+        public void InstantiationKeyMatchesPerPosition()
+        {
+            Assert.True(InstantiationKey.Matches(Key(typeof(GenBase), typeof(int)), Key(typeof(GenDerived), typeof(int))));
+            Assert.False(InstantiationKey.Matches(Key(typeof(GenBase), typeof(int)), Key(typeof(GenDerived), typeof(long))));
+        }
+        #endregion
+    }
+}

--- a/src/MonoMod.UnitTest/RuntimeDetour/Generics/GenericTestBase.cs
+++ b/src/MonoMod.UnitTest/RuntimeDetour/Generics/GenericTestBase.cs
@@ -1,0 +1,17 @@
+extern alias New;
+using New::MonoMod.RuntimeDetour.Generics;
+using System;
+using System.Reflection;
+using Xunit.Abstractions;
+
+namespace MonoMod.UnitTest.RuntimeDetour.Generics
+{
+    public abstract class GenericTestBase(ITestOutputHelper helper) : TestBase(helper)
+    {
+        protected const BindingFlags AllDecl = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance | BindingFlags.DeclaredOnly;
+
+        protected static MethodInfo GetMethod(Type t, string name) => t.GetMethod(name, AllDecl) ?? throw new MissingMethodException(t.FullName, name);
+
+        protected static bool IsShared(MethodInfo openMethod, params Type[] typeArgs) => GenericHelper.MethodIsShared(openMethod.MakeGenericMethod(typeArgs));
+    }
+}

--- a/src/MonoMod.UnitTest/RuntimeDetour/Generics/GenericTestTypes.cs
+++ b/src/MonoMod.UnitTest/RuntimeDetour/Generics/GenericTestTypes.cs
@@ -1,0 +1,147 @@
+﻿using System.Runtime.CompilerServices;
+using Xunit;
+
+namespace MonoMod.UnitTest.RuntimeDetour.Generics
+{
+    public sealed class GenericHookFactAttribute : FactAttribute
+    {
+        public GenericHookFactAttribute()
+        {
+            /*
+            if (false)
+            {
+                Skip = $"Generic hooking is not supported on this environment ({PlatformDetection.OS}, {PlatformDetection.Runtime}, {PlatformDetection.Architecture}).";
+            }
+            */
+        }
+    }
+
+    public class GenBase
+    {
+        public override string ToString() => "B";
+    }
+
+    public class GenDerived : GenBase
+    {
+        public override string ToString() => "D";
+    }
+
+    public class GenUnrelated
+    {
+        public override string ToString() => "U";
+    }
+
+    public static class Src
+    {
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static string UnsharedOrig<T>(T value) => $"orig<{typeof(T).Name}>:{value}";
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static string UnsharedNoOrig<T>(T value) => $"orig<{typeof(T).Name}>:{value}";
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static string SharedOrig<T>(T value) => $"orig<{typeof(T).Name}>:{value}";
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static string SharedNoOrig<T>(T value) => $"orig<{typeof(T).Name}>:{value}";
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static string Both<T>(T value) => $"orig<{typeof(T).Name}>:{value}";
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static string ChainSameUnshared<T>(T value) => $"orig<{typeof(T).Name}>:{value}";
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static string ChainDiffUnshared<T>(T value) => $"orig<{typeof(T).Name}>:{value}";
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static string ChainSameShared<T>(T value) => $"orig<{typeof(T).Name}>:{value}";
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static string ChainDiffShared<T>(T value) => $"orig<{typeof(T).Name}>:{value}";
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static string PrimeAfterUnshared<T>(T value) => $"orig<{typeof(T).Name}>:{value}";
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static string PrimeAfterShared<T>(T value) => $"orig<{typeof(T).Name}>:{value}";
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static string DisposeUnshared<T>(T value) => $"orig<{typeof(T).Name}>:{value}";
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static string DisposeShared<T>(T value) => $"orig<{typeof(T).Name}>:{value}";
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static string DoublePrime<T>(T value) => $"orig<{typeof(T).Name}>:{value}";
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static string CatchNone<T>(T value) => $"orig<{typeof(T).Name}>:{value}";
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static string CatchAll<T>(T value) => $"orig<{typeof(T).Name}>:{value}";
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static string CatchCompatible<T>(T value) => $"orig<{typeof(T).Name}>:{value}";
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static string CatchCompatibleUnrelated<T>(T value) => $"orig<{typeof(T).Name}>:{value}";
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static string GenericHookCtor<T>(T value) => $"orig<{typeof(T).Name}>:{value}";
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static string ChainTripleShared<T>(T value) => $"orig<{typeof(T).Name}>:{value}";
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static string ChainDisposeMiddleShared<T>(T value) => $"orig<{typeof(T).Name}>:{value}";
+
+    }
+
+    public static class SrcTwo
+    {
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static string SameValue<T1, T2>(T1 a, T2 b) => $"orig<{typeof(T1).Name},{typeof(T2).Name}>:{a}|{b}";
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static string SameRef<T1, T2>(T1 a, T2 b) => $"orig<{typeof(T1).Name},{typeof(T2).Name}>:{a}|{b}";
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static string Mixed<T1, T2>(T1 a, T2 b) => $"orig<{typeof(T1).Name},{typeof(T2).Name}>:{a}|{b}";
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static string CompatPerPosition<T1, T2>(T1 a, T2 b) => $"orig<{typeof(T1).Name},{typeof(T2).Name}>:{a}|{b}";
+    }
+
+    public class InstGM
+    {
+        internal string Tag;
+        public InstGM(string tag) => Tag = tag;
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public string Wrap<T>(T value) => $"orig<{typeof(T).Name}>:{Tag}:{value}";
+    }
+
+    public class GcInst<T>
+    {
+        internal T Value;
+        public GcInst(T value) => Value = value;
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public string Describe() => $"orig<{typeof(T).Name}>:{Value}";
+    }
+
+    public static class GcStat<T>
+    {
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static string Make(T value) => $"orig<{typeof(T).Name}>:{value}";
+    }
+
+    public class GcGm<TC>
+    {
+        internal TC First;
+        public GcGm(TC first) => First = first;
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public string Combine<TM>(TM second) => $"orig<{typeof(TC).Name},{typeof(TM).Name}>:{First}+{second}";
+    }
+}


### PR DESCRIPTION
Preface:
- This is a proof of concept. It should not be implemented as is. It's meant as a demonstration on what might be possible.
- I modified the test.yml to upload include a full trace log because that helps when the test host crashes.
- I added `InternalsVisibleToAttribute` to MonoMod.Core for MonoMod.RuntimeDetours because I wasn't sure where to put the classes and just wanted to keep everything in one place for now.
- I'm not sure if this should be part of MonoMod. I originally started this because I needed to detour generics on one specific runtime under specific circumstances. Expanding support to all runtimes/architectures included in the test matrix was only possible by using a lot of tricks of which I'm not sure how reliable they are.

### Disclaimer:
- I had a basic idea for the initial approach. Which worked up to a point.
- .NET Core and anything outside WinX64 caused various issues. At that point I started trying different approaches until one of them worked (worked == gets test to pass), so the current implementation will certainly have issues
- I was pretty unsure on whether some of the things I do already have helpers
- This is a proof of concept, so I ignored potential performance issues

### Basic API:
- Priming:
  - While a detour is applied to a method, the detour will only dispatch for *primed* types. That means that you can detour a type A<T> with your hook H<K>, but your hook will only be called if the concrete T during a call is primed
  - AutoPrimeMode (this only works for reference types, and on Mono it will not work if the generics contain any value type):
    - Since you often don't just want to detour a single concrete type, autoPrime exists.
    - AutoPrimeMode.None: Only the instantiations explicitly primed are hooked
    - AutoPrimeMode.Compatible: will auto-prime any type `t` it encounters if that `t` is compatible with any of your primed types. E.g. if you primed `object`, then `string` will automatically be primed if it's called.
    - AutoPrimeMode.All: will auto-prime any type `t` it encounters.
- API:
```cs
var myHook = new GenericHook(MethodOf(Src), MethodOf(Hook), [[typeof(int)]], AutoPrimeMode.Compatible);
// Src<int> will detour to Hook<int>
// Any other call will not be detoured at this point
myHook.Prime(typeof(object));
// Src<object> will detour to Hook<object>
// Any other call with a reference type will also be detoured, as they are compatible with object
// Any value types other than the already primed int will not be detoured
```

### Design:
[call] =>
- -\> shared (detoured) native body
  - -\> (Mono) GenericContextCaptureStub: move RGCTX reg into an arg reg
  - -\> UniversalDispatcher:
    - -\> Read Generic Context
    - -\> Resolve Instantiation
    - -\> Hit -> SharedDispatchTrampoline -> User Replacement (+orig chain)
    - -\> Miss -> orig

### Caveats:
- You can't prime interfaces (yet?)
- I'm not sure if exceptions are properly handled
- I ignore the detour config
- Comments (especially docstrings for the public API) are missing
- Despite being the platform I originally developed this for; I didn't run the test matrix on Unity Mono (as x86 Mono is not supported and running it in a game seems to cause issues with test discovery)
- Value types all need explicit priming. While this works for what I need it for, I'm not sure that suffices for a general purpose API? I guess it would be possible to use the compile JIT hook on CoreCLR to discover new value type instantiations, but e.g. Mono only exposes a Profiler API for that (and I think that would have performance issues?); maybe there's a better way to implement all of this that would take care of that.
- Mono does not support auto priming if the generics contain at least one value type.
- Unity Mono seems to not work with this sketch. Adding support is pretty simple, however.