### PR TITLE
Move UTF8 string marshalling helpers to shared class

### DIFF
--- a/src/MonoMod.Utils/DynDll.Backend.cs
+++ b/src/MonoMod.Utils/DynDll.Backend.cs
@@ -208,13 +208,13 @@ namespace MonoMod.Utils
 
             public override unsafe bool TryGetExport(IntPtr handle, string name, out IntPtr ptr)
             {
-                var arr = Interop.Unix.MarshalToUtf8(name);
+                var arr = Interop.Xplat.MarshalToUtf8(name);
                 IntPtr result;
                 fixed (byte* pName = arr)
                 {
                     ptr = result = Interop.Windows.GetProcAddress(new((void*)handle), (sbyte*)pName);
                 }
-                Interop.Unix.FreeMarshalledArray(arr);
+                Interop.Xplat.FreeMarshalledArray(arr);
                 return result != IntPtr.Zero;
             }
 

--- a/src/MonoMod.Utils/Interop/Unix.cs
+++ b/src/MonoMod.Utils/Interop/Unix.cs
@@ -61,26 +61,6 @@ namespace MonoMod.Utils.Interop
         [DllImport(DL2, EntryPoint = "dlerror", CallingConvention = CallingConvention.Cdecl)]
         private static extern IntPtr DL2dlerror();
 
-        internal static byte[]? MarshalToUtf8(string? str)
-        {
-            if (str is null)
-                return null;
-
-            var len = Encoding.UTF8.GetByteCount(str);
-            var arr = ArrayPool<byte>.Shared.Rent(len + 1);
-            arr.AsSpan().Clear();
-            var encoded = Encoding.UTF8.GetBytes(str, 0, str.Length, arr, 0);
-            Helpers.DAssert(len == encoded);
-            return arr;
-        }
-
-        internal static void FreeMarshalledArray(byte[]? arr)
-        {
-            if (arr is null)
-                return;
-            ArrayPool<byte>.Shared.Return(arr);
-        }
-
         private enum LibDlType
         {
             LibC,
@@ -117,7 +97,7 @@ namespace MonoMod.Utils.Interop
 
         public static IntPtr DlOpen(string? filename, DlopenFlags flags)
         {
-            var arr = MarshalToUtf8(filename);
+            var arr = Xplat.MarshalToUtf8(filename);
             try
             {
                 fixed (byte* pStr = arr)
@@ -132,7 +112,7 @@ namespace MonoMod.Utils.Interop
             }
             finally
             {
-                FreeMarshalledArray(arr);
+                Xplat.FreeMarshalledArray(arr);
             }
         }
 
@@ -148,7 +128,7 @@ namespace MonoMod.Utils.Interop
 
         public static IntPtr DlSym(IntPtr handle, string symbol)
         {
-            var arr = MarshalToUtf8(symbol);
+            var arr = Xplat.MarshalToUtf8(symbol);
             try
             {
                 fixed (byte* pStr = arr)
@@ -163,7 +143,7 @@ namespace MonoMod.Utils.Interop
             }
             finally
             {
-                FreeMarshalledArray(arr);
+                Xplat.FreeMarshalledArray(arr);
             }
         }
 

--- a/src/MonoMod.Utils/Interop/Xplat.cs
+++ b/src/MonoMod.Utils/Interop/Xplat.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Buffers;
+using System.Text;
+
+namespace MonoMod.Utils.Interop
+{
+    internal static class Xplat
+    {
+        internal static byte[]? MarshalToUtf8(string? str)
+        {
+            if (str is null)
+                return null;
+
+            var len = Encoding.UTF8.GetByteCount(str);
+            var arr = ArrayPool<byte>.Shared.Rent(len + 1);
+            arr.AsSpan().Clear();
+            var encoded = Encoding.UTF8.GetBytes(str, 0, str.Length, arr, 0);
+            Helpers.DAssert(len == encoded);
+            return arr;
+        }
+
+        internal static void FreeMarshalledArray(byte[]? arr)
+        {
+            if (arr is null)
+                return;
+            ArrayPool<byte>.Shared.Return(arr);
+        }
+    }
+}


### PR DESCRIPTION
It turns out that Mono sometimes still eagerly calls BeforeFieldInit cctors. As a result, when the DynDll Windows backend used the stirng marshalling helpers defined in the Unix interop class, the Unix cctor would be called, and try to find a working libdl (which obviously doesn't exist on Windows), and thus fail, throw, and prevent thhe type from loading properly.