### PR TITLE
Fix invalid DynamicMethod JIT exception handling

### DIFF
--- a/src/MonoMod.Core/Interop/CoreCLR.cs
+++ b/src/MonoMod.Core/Interop/CoreCLR.cs
@@ -9,7 +9,7 @@ namespace MonoMod.Core.Interop
         public enum CorJitResult
         {
             CORJIT_OK = 0,
-            // There are more, but I don't particularly care about them
+            CORJIT_BADCODE = unchecked((int)0x80000001),
         }
 
         public readonly struct InvokeCompileMethodPtr

--- a/src/MonoMod.Core/Platforms/Runtimes/Core21Runtime.cs
+++ b/src/MonoMod.Core/Platforms/Runtimes/Core21Runtime.cs
@@ -188,13 +188,18 @@ namespace MonoMod.Core.Platforms.Runtimes
                 try
                 {
 
-                    /* We've silenced any exceptions thrown by this in the past but it turns out this can throw?!
-                     * Let's hope that all runtimes we're hooking the JIT of know how to deal with this - oh wait, not all do!
-                     * FIXME: Linux .NET Core pre-5.0 (and sometimes even 5.0) can die in real_compileMethod on invalid IL?!
-                     * -ade
-                     */
-                    var result = InvokeCompileMethodPtr.InvokeCompileMethod(CompileMethodPtr,
-                        jit, corJitInfo, methodInfo, flags, pNativeEntry, pNativeSizeOfCode);
+                    CorJitResult result;
+                    try
+                    {
+                        result = InvokeCompileMethodPtr.InvokeCompileMethod(CompileMethodPtr,
+                            jit, corJitInfo, methodInfo, flags, pNativeEntry, pNativeSizeOfCode);
+                    }
+                    catch (InvalidProgramException) when (pNEx is not null && *pNEx == IntPtr.Zero)
+                    {
+                        // Managed exceptions cannot escape this hook's POSIX native-to-managed boundary.
+                        // Report invalid IL to CoreCLR so it can throw on its normal managed call path.
+                        return CorJitResult.CORJIT_BADCODE;
+                    }
                     // if a native exception was caught, return immediately and skip all of our normal processing
                     if (pNEx is not null && (nativeException = *pNEx) is not 0)
                     {
@@ -528,4 +533,3 @@ namespace MonoMod.Core.Platforms.Runtimes
         }
     }
 }
-

--- a/src/MonoMod.Core/Platforms/Runtimes/Core60Runtime.cs
+++ b/src/MonoMod.Core/Platforms/Runtimes/Core60Runtime.cs
@@ -248,8 +248,18 @@ namespace MonoMod.Core.Platforms.Runtimes
                         }
                     }
 
-                    var result = InvokeCompileMethodPtr.InvokeCompileMethod(CompileMethodPtr,
-                        jit, corJitInfo, methodInfo, flags, nativeEntry, nativeSizeOfCode);
+                    CorJitResult result;
+                    try
+                    {
+                        result = InvokeCompileMethodPtr.InvokeCompileMethod(CompileMethodPtr,
+                            jit, corJitInfo, methodInfo, flags, nativeEntry, nativeSizeOfCode);
+                    }
+                    catch (InvalidProgramException) when (pNEx is not null && *pNEx == IntPtr.Zero)
+                    {
+                        // Managed exceptions cannot escape this hook's POSIX native-to-managed boundary.
+                        // Report invalid IL to CoreCLR so it can throw on its normal managed call path.
+                        return CorJitResult.CORJIT_BADCODE;
+                    }
                     // if a native exception was caught, return immediately and skip all of our normal processing
                     if (pNEx is not null && (nativeException = *pNEx) is not 0)
                     {

--- a/src/MonoMod.UnitTest/Github/Issue314.cs
+++ b/src/MonoMod.UnitTest/Github/Issue314.cs
@@ -1,4 +1,4 @@
-#if NETCOREAPP
+#if NET5_0_OR_GREATER
 using MonoMod.Core.Platforms;
 using System;
 using System.Reflection;

--- a/src/MonoMod.UnitTest/Github/Issue314.cs
+++ b/src/MonoMod.UnitTest/Github/Issue314.cs
@@ -1,0 +1,42 @@
+#if NETCOREAPP
+using MonoMod.Core.Platforms;
+using System;
+using System.Reflection;
+using System.Reflection.Emit;
+using Xunit;
+
+namespace MonoMod.UnitTest.Github
+{
+    [Collection("RuntimeDetour")]
+    public class Issue314
+    {
+        [Fact]
+        public void DynamicMethodTokenResolutionExceptionRemainsCatchable()
+        {
+            Assert.NotNull(PlatformTriple.Current);
+
+            var invalidMethod = new DynamicMethod(
+                "BadToken",
+                typeof(void),
+                Type.EmptyTypes,
+                typeof(Issue314).Module,
+                skipVisibility: true);
+
+            var invalidIL = invalidMethod.GetDynamicILInfo();
+            invalidIL.SetLocalSignature(SignatureHelper.GetLocalVarSigHelper().GetSignature());
+            // call <bogus MethodDef token 0x06FFFFFF>; ret
+            invalidIL.SetCode(new byte[] { 0x28, 0xFF, 0xFF, 0xFF, 0x06, 0x2A }, maxStackSize: 8);
+
+            var invocationException = Assert.Throws<TargetInvocationException>(() => invalidMethod.Invoke(null, null));
+            Assert.IsType<InvalidProgramException>(invocationException.InnerException);
+
+            var validMethod = new DynamicMethod("Valid", typeof(int), Type.EmptyTypes);
+            var validIL = validMethod.GetILGenerator();
+            validIL.Emit(OpCodes.Ldc_I4, 42);
+            validIL.Emit(OpCodes.Ret);
+
+            Assert.Equal(42, validMethod.CreateDelegate<Func<int>>()());
+        }
+    }
+}
+#endif


### PR DESCRIPTION
## Summary

- translate managed `InvalidProgramException` failures from the POSIX managed JIT hook into `CORJIT_BADCODE`
- preserve the existing native-exception path and Windows exception behavior
- add a regression test using a `DynamicMethod` with a bogus metadata token and verify subsequent JIT compilation remains healthy

Fixes #314.

## Testing

- reproduced the pre-fix process abort on Linux ARM64 / .NET 8.0.29
- regression and existing JIT exception tests pass on Linux .NET 5, 6, 8, 9, and 10
- .NET 8 regression tests pass on Linux x64 and ARM64
- all `MonoMod.Core` target frameworks build successfully
- .NET 8 ARM64 suite excluding `AssemblyLoadContextHookTest`: 284 passed, 2 skipped; that excluded test independently aborts with an unrelated `SEHException`