### PR TITLE
Fix #318 (Wrong method entry point for NGEN-ed method pre 4.8)

### DIFF
--- a/src/MonoMod.Core/Interop/Fx.V48.cs
+++ b/src/MonoMod.Core/Interop/Fx.V48.cs
@@ -107,6 +107,13 @@ namespace MonoMod.Core.Interop
                     {
                         var size = GetBaseSize();
                         var pSlot = ((byte*)Unsafe.AsPointer(ref this)) + size;
+                        // In runtimes before .NET Framework 4.8, NGEN causes slots to contain relative offsets
+                        // https://github.com/MonoMod/MonoMod/issues/318
+                        if (PlatformDetection.RuntimeVersion < new Version(4, 8) && MethodDescChunk->m_flagsAndTokenRange.Has(V48.MethodDescChunk.Flags.IsZapped))
+                        {
+                            var relativeEntryPoint = ((RelativePointer*)pSlot)->Value;
+                            return relativeEntryPoint;
+                        }
 
                         return *(void**)pSlot;
                     }

--- a/src/MonoMod.Core/Platforms/Runtimes/FxCLR4Runtime.cs
+++ b/src/MonoMod.Core/Platforms/Runtimes/FxCLR4Runtime.cs
@@ -36,7 +36,6 @@ namespace MonoMod.Core.Platforms.Runtimes
         public override RuntimeFeature Features
             => base.Features & ~RuntimeFeature.RequiresBodyThunkWalking;
 
-        // TODO: check to make sure we're running 4.8 before using this
         private unsafe IntPtr GetMethodBodyPtr(MethodBase method, RuntimeMethodHandle handle)
         {
             var md = (V48.MethodDesc*)handle.Value;


### PR DESCRIPTION
The issue seems to go back to an update in .NET Framework. .NET Framework 4.8 contains the following in its [changelog](https://learn.microsoft.com/en-us/dotnet/framework/whats-new/#common-language-runtime)
> NGEN improvements [...]

I looked at .NET 4.7.2 and .NET 4.8 binaries and confirmed that the relevant behavior did change in between the two of them.

There is already a test for this behavior in https://github.com/MonoMod/MonoMod/blob/reorganize/src/MonoMod.UnitTest/RuntimeDetour/DetourExtTest.cs#L205. None of the existing runners catch this though because they are based on modern windows which ships .NET Framework 4.8.1. I did test on older runtimes and manually installed .NET 4.6.2 and .NET 4.7.1 and could reproduce the issue with the specified test.

The fix is based on the behavior in [CoreCLR](https://github.com/dotnet/coreclr/blob/v1.0.0/src/vm/method.cpp#L570)
```cpp
if (HasNonVtableSlot())
{
    SIZE_T size = GetBaseSize();

    TADDR pSlot = dac_cast<TADDR>(this) + size;

    return IsZapped() ? NonVtableSlot::GetValueAtPtr(pSlot) : *PTR_PCODE(pSlot);
}
```

I implemented this as a hardcoded condition. A better place for this might be a new `RuntimeFeature` flag. I didn't do that for now since the condition is trivial.

Fixes #318